### PR TITLE
Run AM_PROG_AR to fix build with newer automake

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,7 @@ AM_INIT_AUTOMAKE([-Wall -Werror dist-bzip2 foreign])
 AC_USE_SYSTEM_EXTENSIONS
 AC_CONFIG_MACRO_DIR([m4])
 AM_SILENT_RULES([yes])
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 LT_INIT([disable-static])
 AC_PREFIX_DEFAULT([/usr])
 


### PR DESCRIPTION
With automake 1.12.6, I'm seeing the following warning (treated as an error) when running autogen.sh:

automake: warnings are treated as errors
/usr/share/automake-1.12/am/ltlibrary.am: warning: 'libsmack.la': linking libtool libraries using a non-POSIX
/usr/share/automake-1.12/am/ltlibrary.am: archiver requires 'AM_PROG_AR' in 'configure.ac'
libsmack/Makefile.am:8:   while processing Libtool library 'libsmack.la'
libsmack/Makefile.am: installing 'build-aux/depcomp'
autoreconf: automake failed with exit status: 1

This commit resolves the issue by running AM_PROG_AR if it is defined.
