### PR TITLE
libsmack: check label length in smack_revoke_subject().

### DIFF
--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -519,14 +519,19 @@ int smack_revoke_subject(const char *subject)
 {
 	int ret;
 	int fd;
+	int len;
 	char path[PATH_MAX];
+
+	len = strnlen(subject, SMACK_LABEL_LEN + 1);
+	if (len > SMACK_LABEL_LEN)
+		return -1;
 
 	snprintf(path, sizeof path, "%s/revoke-subject", smack_mnt);
 	fd = open(path, O_WRONLY);
 	if (fd < 0)
 		return -1;
 
-	ret = write(fd, subject, strnlen(subject, SMACK_LABEL_LEN));
+	ret = write(fd, subject, len);
 	close(fd);
 
 	return (ret < 0) ? -1 : 0;


### PR DESCRIPTION
A small fix for smack_revoke_subject() that Jarkko requested in comment to my previous pull request https://github.com/smack-team/smack/pull/6#issuecomment-11838024.
