### PR TITLE
disable services for systemd versions > 198

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,12 +25,19 @@ AM_CONDITIONAL([ENABLE_DOXYGEN],[test ! -z "$DOXYGEN"], [Build API documentation
 AC_SUBST([DOXYGEN], [$DOXYGEN])
 
 # systemd
+systemd_new=no
+PKG_CHECK_MODULES([SYSTEMD],
+                  systemd >= 198,
+                  [systemd_new=yes],
+                  [systemd_new=no])
+
 AC_ARG_WITH([systemdsystemunitdir],
         AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),
         [],
         [with_systemdsystemunitdir=$(pkg-config --silence-errors --variable=systemdsystemunitdir systemd)])
 AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
 AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$with_systemdsystemunitdir"])
+AM_CONDITIONAL(HAVE_SYSTEMD_NEW, [test "$systemd_new" = "yes"])
 
 AC_CONFIG_FILES([Makefile libsmack/Makefile libsmack/libsmack.pc utils/Makefile doc/Makefile init/Makefile])
 

--- a/init/Makefile.am
+++ b/init/Makefile.am
@@ -1,5 +1,9 @@
 if HAVE_SYSTEMD
+if HAVE_SYSTEMD_NEW
+
+else
 systemdsystemunit_DATA = \
         smack.mount \
         smack.service
+endif
 endif


### PR DESCRIPTION
do not install smack.mount or smack.service if systemd is version
198 or higher. This functionality is now built into systemd.
