### PR TITLE
Samsung

### DIFF
--- a/debian/libsmack1.symbols
+++ b/debian/libsmack1.symbols
@@ -11,4 +11,5 @@ libsmack.so.1 libsmack1 #MINVER#
  smack_new_label_from_self@LIBSMACK 1.0
  smack_new_label_from_socket@LIBSMACK 1.0
  smack_revoke_subject@LIBSMACK 1.0
+ smack_accesses_add_modify@LIBSMACK 1.0
  smack_set_label_for_self@LIBSMACK 1.0

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -23,6 +23,7 @@ endif
 man_MANS = smackaccess.1 \
 	   smack_accesses_add.3 \
 	   smack_accesses_add_from_file.3 \
+	   smack_accesses_add_modify.3 \
 	   smack_accesses_apply.3 \
 	   smack_accesses_clear.3 \
 	   smack_accesses_free.3 \

--- a/doc/smack_accesses_add.3
+++ b/doc/smack_accesses_add.3
@@ -34,6 +34,8 @@ smack_accesses_new, smack_accesses_free, smack_accesses_save, smack_accesses_app
 
 .BI "int smack_accesses_add(struct smack_accesses *" handle ", const char *" subject ", const char *" object ", const char *" access_type ");"
 .br
+.BI "int smack_accesses_add_modify(struct smack_accesses *" handle ", const char *" subject ", const char *" object ", const char *" access_add ", const char *" access_del ");"
+.br
 .BI "int smack_accesses_add_from_file(struct smack_accesses *" accesses ", int " fd ");"
 .br
 .BI "int smack_accesses_save(struct smack_accesses *" handle ", int " fd ");"
@@ -69,6 +71,20 @@ with the type of access defined in
 .I access_type
 and store the result in
 .IR handle .
+If a rule for the specified labels already exists it will be overwritten.
+
+.BR smack_accesses_add_modify ()
+create a modification rule for the specified
+.I subject
+and
+.I object
+labels allowing the access specified in
+.I access_add
+and disallowing the access defined by
+.IR access_del .
+The result is stored in
+.IR handle .
+If a rule for the specified labels already exists it will be modified, otherwise a new rule will be created with the permissions specified in access_add added and those specified in access_del removed.
 
 .BR smack_accesses_add_from_file ()
 read a set of rules from a file and store them in

--- a/doc/smack_accesses_add_modify.3
+++ b/doc/smack_accesses_add_modify.3
@@ -1,0 +1,1 @@
+.so man3/smack_accesses_add.3

--- a/libsmack/libsmack.sym
+++ b/libsmack/libsmack.sym
@@ -6,6 +6,7 @@ global:
 	smack_accesses_apply;
 	smack_accesses_clear;
 	smack_accesses_add;
+	smack_accesses_add_modify;
 	smack_accesses_add_from_file;
 	smack_have_access;
         smack_cipso_free;

--- a/libsmack/sys/smack.h
+++ b/libsmack/sys/smack.h
@@ -105,6 +105,24 @@ int smack_accesses_add(struct smack_accesses *handle, const char *subject,
 		       const char *object, const char *access_type);
 
 /*!
+ * Add a modification rule to a rule set.
+ * The modification rule will change access permissions for a given subject and
+ * object.
+ * If such rule already existend (in the kernel or earlier in the rule set),
+ * it will be modified. Otherwise a new rule will be created, with permissions
+ * from access_add minus permissions from access_del.
+ *
+ * @param handle handle to a rule set
+ * @param subject subject of the rule
+ * @param object object of the rule
+ * @param access_add access type
+ * @param access_del access type
+ * @return Returns 0 on success.
+ */
+int smack_accesses_add_modify(struct smack_accesses *handle, const char *subject,
+		       const char *object, const char *access_add, const char *access_del);
+
+/*!
  * Add rules from file.
  *
  * @param accesses instance


### PR DESCRIPTION
Two more patches from Samsung Tizen code:
1.  Parse whole access type string, not only first 5 bytes
   A small patch to avoid errors like "rrwxat".
2. Add support for modification rules
   This adds support for a new kernel interface "change-rule", first appearing in v3.10-rc1
   (http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=e05b6f9).
   It allows adding or removing permissions for a rule instead of overwriting the existing rule.
   
   This patch to libsmack has been previously reviewed and accepted in RSA gerrit, but I waited with sending it here until the proper interface is merged into kernel.
