### PR TITLE
Use xattr.h from libc, not from libattr.

### DIFF
--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -37,7 +37,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <limits.h>
-#include <attr/xattr.h>
+#include <sys/xattr.h>
 
 #define ACC_LEN 5
 #define LOAD_LEN (2 * (SMACK_LABEL_LEN + 1) + 2 * ACC_LEN + 1)


### PR DESCRIPTION
This fixes include in libsmack.c introduced in commit f409c17.
