### PR TITLE
Add smack_label_is_valid() function to check correctness of SMACK label

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -34,6 +34,7 @@ man_MANS = smackaccess.1 \
 	   smack_new_label_from_socket.3 \
 	   smack_new_label_from_path.3 \
 	   smack_set_label_for_self.3 \
+	   smack_is_label_valid.3 \
 	   smack_revoke_subject.3 \
 	   chsmack.8 \
 	   smackcipso.8 \

--- a/doc/smack_have_access.3
+++ b/doc/smack_have_access.3
@@ -19,7 +19,7 @@
 .\"
 .TH "SMACK_HAVE_ACCESS" "3" "06/20/2012" "Libsmack 1\&.0"
 .SH NAME
-smack_have_access, smack_new_label_from_self, smack_new_label_from_socket \- Userspace interaction with Smack
+smack_have_access, smack_new_label_from_self, smack_new_label_from_socket, smack_is_label_valid \- Userspace interaction with Smack
 .SH SYNOPSIS
 .B #include <sys/smack.h>
 .sp
@@ -30,6 +30,8 @@ smack_have_access, smack_new_label_from_self, smack_new_label_from_socket \- Use
 .BI "int smack_set_label_for_self(char **" label ");"
 .br
 .BI "int smack_new_label_from_socket(int " fd ", char **" label ");"
+.br
+.BI "int smack_is_label_valid(const char *" label ");"
 .sp
 .SH DESCRIPTION
 Smack is a Mandatory Access Control (MAC) based security mechanism for the Linux kernel.  It works on the basis of context, which is stored as a label in the extended attributes (xattr) of a file.  When a process is started the kernel ensures that this context is assigned to the running process.  By default a process can only interact with processes and filesystem objects that have the same context as itself and is denied access to all other contexts.  Rules can be created to grant access to other contexts, these are generally created on package installation and can only be modified by a process that has the CAP_MAC_ADMIN capability.
@@ -72,6 +74,11 @@ of the socket and determines it's context and creates a new storage for this whi
 on return.  It is the callers responsibility to free
 .I label
 when it is no longer required.
+.PP
+.BR smack_is_label_valid ()
+takes a
+.IR label ,
+and checks if it's correct Smack label.
 .SH RETURN VALUE
 .BR smack_new_label_from_self ()
 and
@@ -84,3 +91,8 @@ is set appropriately).
 returns 1 if allowed, 0 if no access and \-1 on error (in which case,
 .I errno
 is set appropriately).
+
+.BR smack_is_label_valid ()
+returns 1 if
+.I label
+is valid and 0 if it's not.

--- a/doc/smack_is_label_valid.3
+++ b/doc/smack_is_label_valid.3
@@ -1,0 +1,1 @@
+.so man3/smack_have_access.3

--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -734,4 +734,25 @@ static inline void parse_access_type(const char *in, char out[ACC_LEN + 1])
 		}
 }
 
+int smack_is_label_valid(const char *label)
+{
+	int i;
 
+	if (!label || label[0] == '\0' || label[0] == '-')
+		return 0;
+
+	for (i = 0; i < SMACK_LABEL_LEN && label[i]; ++i) {
+		switch (label[i]) {
+		case ' ':
+		case '/':
+		case '"':
+		case '\\':
+		case '\'':
+			return 0;
+		default:
+			break;
+		}
+	}
+
+	return i < SMACK_LABEL_LEN;
+}

--- a/libsmack/libsmack.sym
+++ b/libsmack/libsmack.sym
@@ -22,3 +22,8 @@ global:
 local:
 	*;
 };
+
+LIBSMACK_1.1 {
+global:
+	smack_is_label_valid;
+} LIBSMACK_1.0;

--- a/libsmack/sys/smack.h
+++ b/libsmack/sys/smack.h
@@ -241,6 +241,14 @@ int smack_set_label_for_self(const char *label);
  */
 int smack_revoke_subject(const char *subject);
 
+/*!
+ * Check if SMACK label is valid
+ *
+ * @param label to verify
+ * @return 1 if label is correct and 0 if it's not
+ */
+int smack_is_label_valid(const char *label);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Kernel does not validate the Smack label - instead the label will be
cut on the first incorrect character (after parsing at least one
correct character).
This function gives the user possibility to verify the correctness
of the Smack label before use
