### PR TITLE
Fix a Segfault on long labels

### DIFF
--- a/utils/chsmack.c
+++ b/utils/chsmack.c
@@ -48,20 +48,18 @@ int main(int argc, char *argv[])
 
 	int transmute_flag = 0;
 	int option_flag = 0;
-	int option_index;
 	int rc;
 	int c;
 	int i;
 
 	while ((c = getopt_long(argc, argv, "a:e:m:t", long_options,
-				&option_index)) != -1) {
+				NULL)) != -1) {
 		if ((c == 'a' || c == 'e' || c == 'm')
 		    && strnlen(optarg, SMACK_LABEL_LEN + 1)
 		       == (SMACK_LABEL_LEN + 1)) {
-			fprintf(stderr, "%s label \"%s\" "
+			fprintf(stderr, "label \"%s\" "
 					"exceeds %d characters.\n",
-				long_options[option_index].name, optarg,
-				SMACK_LABEL_LEN);
+				optarg, SMACK_LABEL_LEN);
 			exit(1);
 		}
 


### PR DESCRIPTION
The program 'chsmack' was crashing with a 'segmentation fault' when called with label longer than 255 characters, as, for example: chsmack -a $(head -c256 /dev/zero | tr '\0' x) afile

The problem came from the function getopt_long and from how it was used. Removing any reference to its 5th parameter (replaced with NULL) solves the problem.

I also inserted a exit in case of error. This is better to my eyes to abort any action in case of error than to perform only some, as it was the case.
