### PR TITLE
labels of 255 characters can't be set with chsmack

### DIFF
--- a/utils/chsmack.c
+++ b/utils/chsmack.c
@@ -94,21 +94,21 @@ int main(int argc, char *argv[])
 		if (option_flag) {
 			if (strlen(access_buf) > 0) {
 				rc = lsetxattr(argv[i], "security.SMACK64",
-					       access_buf, strlen(access_buf) + 1, 0);
+					       access_buf, strlen(access_buf), 0);
 				if (rc < 0)
 					perror(argv[i]);
 			}
 
 			if (strlen(exec_buf) > 0) {
 				rc = lsetxattr(argv[i], "security.SMACK64EXEC",
-					       exec_buf, strlen(exec_buf) + 1, 0);
+					       exec_buf, strlen(exec_buf), 0);
 				if (rc < 0)
 					perror(argv[i]);
 			}
 
 			if (strlen(mmap_buf) > 0) {
 				rc = lsetxattr(argv[i], "security.SMACK64MMAP",
-					       mmap_buf, strlen(mmap_buf) + 1, 0);
+					       mmap_buf, strlen(mmap_buf), 0);
 				if (rc < 0)
 					perror(argv[i]);
 			}


### PR DESCRIPTION
Setting labels of 255 characters causes chsmack to invoque lsetxattr for a value of 256 bytes what is rejected as "invalid argument".

It seems that smack includes a terminating null char to it's setting for label.

A decision has to be taken (it is maybe already taken, i don't know...):
- tell that smack labels are strings up to 254 characters
  or
- review the code to ensure that the terminating null for strings of 255 characters can be removed
