### PR TITLE
Solve problem with "make distcheck" breaking on systemd config files.

### DIFF
--- a/init/Makefile.am
+++ b/init/Makefile.am
@@ -7,3 +7,7 @@ systemdsystemunit_DATA = \
         smack.service
 endif
 endif
+
+EXTRA_DIST = \
+        smack.mount \
+        smack.service


### PR DESCRIPTION
Dist packages created by "make dist" were built without smack.mount and
smack.service files. This caused the packages to fail to build.
Adding the files to EXTRA_DIST solves the problem.
This fixes #48 issue.
