### PR TITLE
init/ causes make distcheck to fail

### DIFF
--- a/init/Makefile.am
+++ b/init/Makefile.am
@@ -7,3 +7,7 @@ systemdsystemunit_DATA = \
         smack.service
 endif
 endif
+
+EXTRA_DIST = \
+        smack.mount \
+        smack.service


### PR DESCRIPTION
Must be fixed for v1.0.2 release. Should we just remove it considering that systemd has SMACK support in place?
