### PR TITLE
Fix memory leak on smack_cipso

### DIFF
--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -357,6 +357,8 @@ void smack_cipso_free(struct smack_cipso *cipso)
 		free(mapping);
 		mapping = next_mapping;
 	}
+
+	free(cipso);
 }
 
 int smack_cipso_apply(struct smack_cipso *cipso)


### PR DESCRIPTION
smack_cipso_free() didn't release main pointer, which was
inconsistent with header description and further usage in
apply_cipso_file().
