### PR TITLE
More verbose reporting when applying access rules or CIPSO

### DIFF
--- a/utils/common.h
+++ b/utils/common.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of libsmack.
  *
- * Copyright (C) 2011 Intel Corporation
+ * Copyright (C) 2011-2013 Intel Corporation
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License
@@ -27,7 +27,7 @@
 int clear(void);
 int apply_rules(const char *path, int clear);
 int apply_cipso(const char *path);
-int apply_rules_file(int fd, int clear);
-int apply_cipso_file(int fd);
+int apply_rules_file(const char *path, int fd, int clear);
+int apply_cipso_file(const char *path, int fd);
 
 #endif // COMMON_H

--- a/utils/smackcipso.c
+++ b/utils/smackcipso.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
 	}
 
 	if (argc == 1) {
-		if (apply_cipso_file(STDIN_FILENO))
+		if (apply_cipso_file(NULL, STDIN_FILENO))
 			exit(1);
 	} else {
 		if (apply_cipso(argv[1]))

--- a/utils/smackload.c
+++ b/utils/smackload.c
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
 	}
 
 	if (optind == argc) {
-		if (apply_rules_file(STDIN_FILENO, clear))
+		if (apply_rules_file(NULL, STDIN_FILENO, clear))
 			exit(1);
 	} else {
 		if (apply_rules(argv[optind], clear))


### PR DESCRIPTION
To make debugging easier `smackload` said whether writing rules to kernel or reading them from rules file failed.
