### PR TITLE
Segfault in smack_revoke_subject() and smack_set_label_for_self()

### DIFF
--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -740,7 +740,7 @@ static inline ssize_t get_label(char *dest, const char *src)
 			dest[i] = src[i];
 	}
 
-	if (i < (SMACK_LABEL_LEN + 1))
+	if (dest && i < (SMACK_LABEL_LEN + 1))
 		dest[i] = '\0';
 
 	return i < (SMACK_LABEL_LEN + 1) ? i : -1;


### PR DESCRIPTION
Pull request #46  caused this API function to segfault. It uses `get_label(NULL, label)` in these API functions, but `get_label()` unconditionally treats first argument as a valid pointer.
