### PR TITLE
libsmack: parse whole access type string, not only first 5 bytes.

### DIFF
--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -752,7 +752,7 @@ static inline int str_to_access_code(const char *str)
 	int i;
 	unsigned int code = 0;
 
-	for (i = 0; i < ACC_LEN && str[i] != '\0'; i++) {
+	for (i = 0; str[i] != '\0'; i++) {
 		switch (str[i]) {
 		case 'r':
 		case 'R':


### PR DESCRIPTION
Previous version of this function parsed only first ACC_LEN (5)
characters of access_type. Now the whole string will be read.

This will prevent silent ignoring of access type characters in cases
like "-rwxat" or "rrwxat".

Re-applying because it was reverted by d2283792.
