### PR TITLE
smack_cipso_apply() fails when applying multiple rules

### DIFF
--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -390,7 +390,7 @@ int smack_cipso_apply(struct smack_cipso *cipso)
 	int fd;
 	int i;
 	char path[PATH_MAX];
-	int offset=0;
+	int offset;
 
 	if (!smackfs_mnt)
 		return -1;
@@ -403,7 +403,7 @@ int smack_cipso_apply(struct smack_cipso *cipso)
 	memset(buf,0,CIPSO_MAX_SIZE);
 	for (m = cipso->first; m != NULL; m = m->next) {
 		snprintf(buf, SMACK_LABEL_LEN + 1, "%s", m->label);
-		offset += strlen(buf) + 1;
+		offset = strlen(buf) + 1;
 
 		sprintf(&buf[offset], CIPSO_NUM_LEN_STR, m->level);
 		offset += NUM_LEN;


### PR DESCRIPTION
A typo in f47b9c90 caused invalid buffer handling between output rules. This manifests itself when there are at least two rules and a rule with shorter subject comes first:

```
# smackcipso <<END
test1 250/2,3,4,6,10,11,14,16,18,19,20,23,24,26,27,28,30,35,36,40
test12 250/2,3,4,6,10,11,14,16,18,19,20,23,24,26,27,28,30,35,36,40,43,44,47
END
Applying CIPSO failed.
```
