### PR TITLE
"smackctl apply" fails with "Uknown action: apply"

### DIFF
--- a/utils/smackctl.c
+++ b/utils/smackctl.c
@@ -65,8 +65,10 @@ int main(int argc, char **argv)
 		else
 			printf("SmackFS is not mounted.\n");
 		exit(0);
+	} else {
+		fprintf(stderr, "Uknown action: %s\n", argv[1]);
+		exit(1);
 	}
 
-	fprintf(stderr, "Uknown action: %s\n", argv[1]);
-	exit(1);
+	exit(0);
 }


### PR DESCRIPTION
After correctly performing it's action, smackctl fails with the above error message. This happens for both "smackctl apply" and "smackctl clear". This seems to be caused by ce452ab.
