### PR TITLE
Use fts functions for scanning directories

### DIFF
--- a/utils/common.c
+++ b/utils/common.c
@@ -19,22 +19,21 @@
  */
 
 #include "common.h"
-#include <dirent.h>
+#include <unistd.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <ftw.h>
+#include <fts.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/smack.h>
+#include <linux/limits.h>
 
 #define SMACK_MAGIC 0x43415d53
 
-static int apply_cipso_cb(const char *fpath, const struct stat *sb,
-			  int typeflag, struct FTW *ftwbuf);
+typedef int (*add_func)(void *smack, int fd);
 
 int clear(void)
 {
-	int fd;
 	int ret;
 	const char * smack_mnt;
 	char path[PATH_MAX];
@@ -44,181 +43,137 @@ int clear(void)
 		return -1;
 
 	snprintf(path, sizeof path, "%s/load2", smack_mnt);
-	fd = open(path, O_RDONLY);
-	if (fd < 0) {
-		fprintf(stderr, "open() failed for '%s' : %s\n", path,
-			strerror(errno));
-		return -1;
-	}
-
-	ret = apply_rules_file(path, fd, 1);
-	close(fd);
+	ret = apply_rules(path, 1);
 	return ret;
 }
 
-int apply_rules(const char *path, int clear)
+static int fts_cmp(const FTSENT **s1, const FTSENT **s2)
 {
-	DIR *dir;
-	struct dirent *dent;
-	int dfd;
+	return strcoll((*s1)->fts_name, (*s2)->fts_name);
+}
+
+static int apply_files(const char *path, add_func func, void *smack)
+{
+	FTS *fts = NULL;
+	FTSENT *ftsent;
 	int fd;
-	int ret;
+	int ret = 0;
+	const char *path_argv[] = {path, NULL};
 
-	dir = opendir(path);
-	if (dir) {
-		for (dfd = dirfd(dir), dent = readdir(dir);
-		     dent != NULL; dent = readdir(dir)) {
-			if (dent->d_type != DT_REG)
-				continue;
-
-			fd = openat(dfd, dent->d_name, O_RDONLY);
-			if (fd == -1) {
-				fprintf(stderr, "openat() failed for '%s' : %s\n",
-					dent->d_name, strerror(errno));
-				closedir(dir);
-				return -1;
-			}
-
-			ret = apply_rules_file(dent->d_name, fd, clear);
-			close(fd);
-			if (ret < 0) {
-				closedir(dir);
-				return -1;
-			}
-		}
-
-		closedir(dir);
-		return 0;
+	if (path == NULL) {
+		ret = func(smack, STDIN_FILENO);
+		if (ret < 0)
+			fprintf(stderr, "Parsing from STDIN failed.\n");
+		return ret;
 	}
 
-	if (errno != ENOTDIR) {
-		fprintf(stderr, "opendir() failed for '%s' : %s\n",
+	fts = fts_open((char * const *) path_argv,
+		FTS_PHYSICAL | FTS_NOSTAT, fts_cmp);
+
+	if (fts == NULL) {
+		fprintf(stderr, "fts_open() failed for '%s' : %s\n",
 			path, strerror(errno));
 		return -1;
 	}
 
-	fd = open(path, O_RDONLY);
-	if (fd < 0) {
-		fprintf(stderr, "open() failed for '%s' : %s\n", path,
-			strerror(errno));
-		return -1;
+	while ((ftsent = fts_read(fts)) != NULL) {
+		switch (ftsent->fts_info) {
+		case FTS_DEFAULT:
+		case FTS_NSOK:
+		case FTS_SL:
+		case FTS_F:
+			fd = open(ftsent->fts_accpath, O_RDONLY);
+			if (fd == -1) {
+				fprintf(stderr, "open() failed for '%s' : %s\n",
+					ftsent->fts_accpath, strerror(errno));
+				ret = -1;
+				goto out;
+			}
+
+			ret = func(smack, fd);
+			close(fd);
+			if (ret < 0) {
+				fprintf(stderr, "Parsing from '%s' failed.\n",
+					ftsent->fts_accpath);
+				ret = -1;
+				goto out;
+			}
+			break;
+		case FTS_D:
+			if (ftsent->fts_level > 0)
+				fts_set(fts, ftsent, FTS_SKIP);
+			break;
+		case FTS_ERR:
+			fprintf(stderr, "fts_read() failed : %s\n",
+				strerror(ftsent->fts_errno));
+			ret = -1;
+			goto out;
+		case FTS_DNR:
+		case FTS_NS:
+			fprintf(stderr, "fts_read() failed for '%s' : %s\n",
+				ftsent->fts_accpath, strerror(ftsent->fts_errno));
+			ret = -1;
+			goto out;
+		}
 	}
 
-	ret = apply_rules_file(path, fd, clear);
-	close(fd);
+out:
+	fts_close(fts);
 	return ret;
+
 }
 
-int apply_cipso(const char *path)
-{
-	struct stat sbuf;
-	int fd;
-	int ret;
-
-	if (stat(path, &sbuf)) {
-		fprintf(stderr, "stat() failed for '%s' : %s\n", path,
-			strerror(errno));
-		return -1;
-	}
-
-	if (S_ISDIR(sbuf.st_mode))
-		return nftw(path, apply_cipso_cb, 1, FTW_PHYS|FTW_ACTIONRETVAL);
-
-	fd = open(path, O_RDONLY);
-	if (fd < 0) {
-		fprintf(stderr, "open() failed for '%s' : %s\n", path,
-			strerror(errno));
-		return -1;
-	}
-
-	ret = apply_cipso_file(path, fd);
-	close(fd);
-	return ret;
-}
-
-int apply_rules_file(const char *path, int fd, int clear)
+int apply_rules(const char *path, int clear)
 {
 	struct smack_accesses *rules = NULL;
-	int ret = 0;
+	int ret;
 
-	if (smack_accesses_new(&rules))
+	if (smack_accesses_new(&rules)) {
+		fprintf(stderr, "Out of memory.\n");
 		return -1;
+	}
 
-	if (smack_accesses_add_from_file(rules, fd)) {
+	ret = apply_files(path, (add_func) smack_accesses_add_from_file, rules);
+	if (ret) {
 		smack_accesses_free(rules);
-		if (path)
-			fprintf(stderr, "Reading rules from '%s' failed.\n",
-				path);
-		else
-			fputs("Reading rules from STDIN failed.\n", stderr);
-		return -1;
+		return ret;
 	}
 
 	if (clear) {
 		ret = smack_accesses_clear(rules);
 		if (ret)
-			fputs("Clearing rules failed.\n", stderr);
+			fprintf(stderr, "Clearing rules failed.\n");
 	} else {
 		ret = smack_accesses_apply(rules);
 		if (ret)
-			fputs("Applying rules failed.\n", stderr);
+			fprintf(stderr, "Applying rules failed.\n");
 	}
 
 	smack_accesses_free(rules);
 	return ret;
 }
 
-int apply_cipso_file(const char *path, int fd)
+int apply_cipso(const char *path)
 {
 	struct smack_cipso *cipso = NULL;
 	int ret;
 
-	ret = smack_cipso_new(&cipso);
-	if (ret)
+	if (smack_cipso_new(&cipso)) {
+		fprintf(stderr, "Out of memory.\n");
 		return -1;
+	}
 
-	ret = smack_cipso_add_from_file(cipso, fd);
+	ret = apply_files(path, (add_func) smack_cipso_add_from_file, cipso);
 	if (ret) {
-		if (path)
-			fprintf(stderr, "Reading CIPSO from '%s' failed.\n",
-				path);
-		else
-			fputs("Reading CIPSO from STDIN failed.\n",
-			      stderr);
 		smack_cipso_free(cipso);
-		return -1;
+		return ret;
 	}
 
 	ret = smack_cipso_apply(cipso);
-	smack_cipso_free(cipso);
-	if (ret) {
+	if (ret)
 		fprintf(stderr, "Applying CIPSO failed.\n",
 			path);
-		return -1;
-	}
 
-	return 0;
-}
-
-static int apply_cipso_cb(const char *fpath, const struct stat *sb,
-			  int typeflag, struct FTW *ftwbuf)
-{
-	int fd;
-	int ret;
-
-	if (typeflag == FTW_D)
-		return ftwbuf->level ? FTW_SKIP_SUBTREE : FTW_CONTINUE;
-	else if (typeflag != FTW_F)
-		return FTW_STOP;
-
-	fd = open(fpath, O_RDONLY);
-	if (fd < 0) {
-		fprintf(stderr, "open() failed for '%s' : %s\n", fpath,
-			strerror(errno));
-		return -1;
-	}
-
-	ret = apply_cipso_file(fpath, fd) ? FTW_STOP : FTW_CONTINUE;
-	close(fd);
+	smack_cipso_free(cipso);
 	return ret;
 }

--- a/utils/smackcipso.c
+++ b/utils/smackcipso.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
 	}
 
 	if (argc == 1) {
-		if (apply_cipso_file(NULL, STDIN_FILENO))
+		if (apply_cipso(NULL))
 			exit(1);
 	} else {
 		if (apply_cipso(argv[1]))

--- a/utils/smackload.c
+++ b/utils/smackload.c
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
 	}
 
 	if (optind == argc) {
-		if (apply_rules_file(NULL, STDIN_FILENO, clear))
+		if (apply_rules(NULL, clear))
 			exit(1);
 	} else {
 		if (apply_rules(argv[optind], clear))


### PR DESCRIPTION
The BSD functions `fts_open()` and `fts_read()` are a nice alternative to ftw/ntfw and manual directory reading. This commit replaces existing `readdir()` and `nftw()` usage to get:
- applying CIPSO rules in one shot, just like regular rules
  - [**jsakkine:** Regular rules are not yet applied in one shot. #53 has not yet been merged. I would merge that first and even that after profiling. You can propose something similar for CIPSO but is there large CIPSO data sets even used?] 
- sort input files alphabetically to load them in a defined order (`readdir()` order is file system dependant)
  - [**jsakkine:** This not a benefit.]
- loading rules works on file systems not setting d_type on `readdir()` (fix 233dc30 regression)
  - [**jsakkine:** I would first consider fixing this regression.]
- better performance compared to `nftw()` due to fewer calls to `stat()` internally
  - [**jsakkine:** As far as I know `nftw()` is not used anymore to load access rules, only CIPSO uses it. I'm willing to take a patch to fix that.]
- shorter code due to unified handling of load from file and from directory
  - [**jsakkine:** I'm not a fan of callbacks or unnecessary function pointers. At least I would propose that part in a separate patch.]
