### PR TITLE
wrong return value of function smack_new_label_from_path()

### DIFF
--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -588,7 +588,7 @@ ssize_t smack_new_label_from_path(const char *path, const char *xattr,
 	}
 
 	*label = result;
-	return 0;
+	return ret;
 }
 
 int smack_set_label_for_self(const char *label)


### PR DESCRIPTION
despite its documentation and the convention of the other neighborhood function, the function  smack_new_label_from_path() returns 0 on succes instead of the label length.
