### PR TITLE
Adding smack_new_label_from_pid

### DIFF
--- a/debian/libsmack1.symbols
+++ b/debian/libsmack1.symbols
@@ -9,6 +9,7 @@ libsmack.so.1 libsmack1 #MINVER#
  smack_accesses_save@LIBSMACK 1.0
  smack_have_access@LIBSMACK 1.0
  smack_new_label_from_self@LIBSMACK 1.0
+ smack_new_label_from_pid@LIBSMACK 1.0
  smack_new_label_from_socket@LIBSMACK 1.0
  smack_revoke_subject@LIBSMACK 1.0
  smack_accesses_add_modify@LIBSMACK 1.0

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -45,6 +45,7 @@ EXTRA_MANS = \
 	man/man3/smack_label_length.3 \
 	man/man3/smack_new_label_from_path.3 \
 	man/man3/smack_new_label_from_self.3 \
+	man/man3/smack_new_label_from_pid.3 \
 	man/man3/smack_new_label_from_socket.3 \
 	man/man3/smack_revoke_subject.3 \
 	man/man3/smack_set_label_for_self.3 \

--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -34,6 +34,8 @@
 #include <sys/xattr.h>
 
 #define SELF_LABEL_FILE "/proc/self/attr/current"
+#define PROC_DIR "/proc"
+#define ATTR_CURRENT_FILE "/attr/current"
 
 #define SHORT_LABEL_LEN 23
 #define ACC_LEN 6
@@ -511,9 +513,10 @@ const char *smack_smackfs_path(void)
 	return smackfs_mnt;
 }
 
-ssize_t smack_new_label_from_self(char **label)
+ssize_t smack_new_label_from_pid(pid_t pid, char **label)
 {
 	char *result;
+	char path[PATH_MAX];
 	int fd;
 	int ret;
 
@@ -521,7 +524,9 @@ ssize_t smack_new_label_from_self(char **label)
 	if (result == NULL)
 		return -1;
 
-	fd = open(SELF_LABEL_FILE, O_RDONLY);
+	snprintf(path, sizeof path, "%s/%d/%s", PROC_DIR, pid, ATTR_CURRENT_FILE);
+
+	fd = open(path, O_RDONLY);
 	if (fd < 0) {
 		free(result);
 		return -1;
@@ -536,6 +541,15 @@ ssize_t smack_new_label_from_self(char **label)
 
 	*label = result;
 	return ret;
+}
+
+ssize_t smack_new_label_from_self(char **label)
+{
+	pid_t pid;
+
+	pid = getpid();
+	return smack_new_label_from_pid(pid, label);
+
 }
 
 ssize_t smack_new_label_from_socket(int fd, char **label)

--- a/libsmack/libsmack.sym
+++ b/libsmack/libsmack.sym
@@ -15,6 +15,7 @@ global:
 	smack_cipso_add_from_file;
 	smack_smackfs_path;
 	smack_new_label_from_self;
+	smack_new_label_from_pid;
 	smack_new_label_from_socket;
 	smack_new_label_from_path;
 	smack_set_label_for_self;

--- a/libsmack/sys/smack.h
+++ b/libsmack/sys/smack.h
@@ -202,6 +202,17 @@ const char *smack_smackfs_path(void);
 ssize_t smack_new_label_from_self(char **label);
 
 /*!
+  * Get the label that is associated with the given process id.
+  * Caller is responsible of freeing the returned label.
+  *
+  * @param pid process id
+  * @param label output variable for the label
+  * @return Returns length of the label on success and negative value
+  * on failure.
+  */
+ssize_t smack_new_label_from_pid(pid_t pid, char **label);
+
+/*!
   * Get the label that is associated with a peer on the other end of a
   * UDS socket (SO_PEERSEC). Caller is responsible of freeing the returned
   * label.


### PR DESCRIPTION
Adding new function to libsmack - getting label of process with given PID
by reading label of process from /proc/PID/attr/current
