### PR TITLE
libsmack: fix a bug in validation of labels

### DIFF
--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -742,8 +742,9 @@ static inline ssize_t get_label(char *dest, const char *src)
 		return -1;
 
 	for (i = 0; i < (SMACK_LABEL_LEN + 1) && src[i]; i++) {
+		if (src[i] <= ' ' || src[i] > '~')
+			return -1;
 		switch (src[i]) {
-		case ' ':
 		case '/':
 		case '"':
 		case '\\':


### PR DESCRIPTION
The function `get_label` didn't handle the characters below
' ' (SPACE) and above '~' correctly.

Signed-off-by: José Bollo jose.bollo@open.eurogiciel.org
