### PR TITLE
chsmack: updating to the branch master

### DIFF
--- a/utils/chsmack.c
+++ b/utils/chsmack.c
@@ -45,30 +45,6 @@ static const char usage[] =
 ;
 
 /*!
- * Validate a SMACK label and calculate its length.
- *
- * @param label label to verify
- * @return Returns length of the label on success and negative on failure.
- */
-static ssize_t smack_label_length(const char *label)
-{
-	int i;
-
-	if (!label || !*label || *label=='-')
-		return -1;
-
-	for (i = 0 ; i <= SMACK_LABEL_LEN ; i++) {
-		if (label[i] == '\0')
-				return (ssize_t) i;
-		if (label[i] > '~' || label[i] <= ' ' || label[i] == '/' ||
-		    label[i] == '"' || label[i] == '\\' || label[i] == '\'')
-				return -1;
-	}
-
-	return -1;
-}
-
-/*!
   * Set the SMACK label in an extended attribute.
   *
   * @param path path of the file


### PR DESCRIPTION
The function smack_label_length is available as a library
function provided by libsmack. It is better to use it for
validating labels instead of redefining it in chsmack.

Signed-off-by: José Bollo jose.bollo@open.eurogiciel.org
