### PR TITLE
libsmack: add functions for setting and removing labels on files

### DIFF
--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -646,6 +646,31 @@ ssize_t smack_new_label_from_path(const char *path, const char *xattr,
 	return ret;
 }
 
+int smack_set_label_for_path(const char *path,
+				  const char *xattr,
+				  int follow,
+				  const char *label)
+{
+	int len;
+	int ret;
+
+	len = (int)smack_label_length(label);
+	if (len < 0)
+		return -2;
+
+	ret = follow ?
+		setxattr(path, xattr, label, len, 0) :
+		lsetxattr(path, xattr, label, len, 0);
+	return ret;
+}
+
+int smack_remove_label_for_path(const char *path,
+				  const char *xattr,
+				  int follow)
+{
+	return follow ? removexattr(path, xattr) : lremovexattr(path, xattr);
+}
+
 int smack_set_label_for_self(const char *label)
 {
 	int len;

--- a/libsmack/libsmack.sym
+++ b/libsmack/libsmack.sym
@@ -26,6 +26,8 @@ local:
 LIBSMACK_1.1 {
 global:
 	smack_label_length;
+	smack_set_label_for_path;
+	smack_remove_label_for_path;
 local:
 	*;
 } LIBSMACK_1.0;

--- a/libsmack/sys/smack.h
+++ b/libsmack/sys/smack.h
@@ -230,6 +230,33 @@ ssize_t smack_new_label_from_path(const char *path,
 				  char **label);
 
 /*!
+  * Set the SMACK label in an extended attribute.
+  *
+  * @param path path of the file
+  * @param xattr the extended attribute containing the SMACK label
+  * @param follow whether or not to follow symbolic link
+  * @param label output variable for the returned label
+  * @return Returns length of the label on success and negative value
+  * on failure.
+  */
+int smack_set_label_for_path(const char *path,
+				  const char *xattr,
+				  int follow,
+				  const char *label);
+
+/*!
+  * Remove the SMACK label in an extended attribute.
+  *
+  * @param path path of the file
+  * @param xattr the extended attribute containing the SMACK label
+  * @param follow whether or not to follow symbolic link
+  * @return Returns 0 on success and negative on failure.
+  */
+int smack_remove_label_for_path(const char *path,
+				  const char *xattr,
+				  int follow);
+
+/*!
  * Set the label associated with the callers process. The caller must have
  * CAP_MAC_ADMIN POSIX capability in order to do this.
  *

--- a/utils/chsmack.c
+++ b/utils/chsmack.c
@@ -43,49 +43,6 @@ static const char usage[] =
 	" -L --dereference   tell to follow the symbolic links\n"
 ;
 
-/*!
-  * Set the SMACK label in an extended attribute.
-  *
-  * @param path path of the file
-  * @param xattr the extended attribute containing the SMACK label
-  * @param follow whether or not to follow symbolic link
-  * @param label output variable for the returned label
-  * @return Returns length of the label on success and negative value
-  * on failure.
-  */
-static int smack_set_label_for_path(const char *path,
-				  const char *xattr,
-				  int follow,
-				  const char *label)
-{
-	int len;
-	int ret;
-
-	len = (int)smack_label_length(label);
-	if (len < 0)
-		return -2;
-
-	ret = follow ?
-		setxattr(path, xattr, label, len, 0) :
-		lsetxattr(path, xattr, label, len, 0);
-	return ret;
-}
-
-/*!
-  * Remove the SMACK label in an extended attribute.
-  *
-  * @param path path of the file
-  * @param xattr the extended attribute containing the SMACK label
-  * @param follow whether or not to follow symbolic link
-  * @return Returns 0 on success and negative on failure.
-  */
-static int smack_remove_label_for_path(const char *path,
-				  const char *xattr,
-				  int follow)
-{
-	return follow ? removexattr(path, xattr) : lremovexattr(path, xattr);
-}
-
 /* main */
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
Functions smack_set_label_for_path and smack_remove_label_for_path have been added as private to chsmack code in version 1.0.4. Since they are generally useful, they should be exported in libsmack 1.1.
Moving code from chsmack to libsmack.
