### PR TITLE
libsmack: Removes checking smackfs isn't read only

### DIFF
--- a/libsmack/init.c
+++ b/libsmack/init.c
@@ -111,22 +111,16 @@ static int verify_smackfs_mnt(const char *mnt)
 
 	if (rc == 0) {
 		if ((uint32_t) sfbuf.f_type == (uint32_t) SMACK_MAGIC) {
-			struct statvfs vfsbuf;
-			rc = statvfs(mnt, &vfsbuf);
-			if (rc == 0) {
-				if (!(vfsbuf.f_flag & ST_RDONLY)) {
-					pthread_mutex_lock(&smackfs_mnt_lock);
-					if (smackfs_mnt_dirfd == -1) {
-						smackfs_mnt = strdup(mnt);
-						smackfs_mnt_dirfd = fd;
-					} else {
-						/* Some other thread won the race. */
-						close(fd);
-					}
-					pthread_mutex_unlock(&smackfs_mnt_lock);
-					return 0;
-				}
+			pthread_mutex_lock(&smackfs_mnt_lock);
+			if (smackfs_mnt_dirfd == -1) {
+				smackfs_mnt = strdup(mnt);
+				smackfs_mnt_dirfd = fd;
+			} else {
+				/* Some other thread won the race. */
+				close(fd);
 			}
+			pthread_mutex_unlock(&smackfs_mnt_lock);
+			return 0;
 		}
 	}
 


### PR DESCRIPTION
Assuming that smack is available only if the filesystem
smackfs is mounted without being set to read-only have
negative side effects on tools like 'id', 'ls', 'ps'.
In effect, these tools are using libsmack to detect
availability of Smack and to tune their output to
print contexts.

This fixes smack-team/smack#105

Signed-off-by: José Bollo jose.bollo@open.eurogiciel.org
