### PR TITLE
libsmack: `verify_smackfs_mnt` wrongly expects smackfs to be writable

### DIFF
--- a/libsmack/init.c
+++ b/libsmack/init.c
@@ -111,22 +111,16 @@ static int verify_smackfs_mnt(const char *mnt)
 
 	if (rc == 0) {
 		if ((uint32_t) sfbuf.f_type == (uint32_t) SMACK_MAGIC) {
-			struct statvfs vfsbuf;
-			rc = statvfs(mnt, &vfsbuf);
-			if (rc == 0) {
-				if (!(vfsbuf.f_flag & ST_RDONLY)) {
-					pthread_mutex_lock(&smackfs_mnt_lock);
-					if (smackfs_mnt_dirfd == -1) {
-						smackfs_mnt = strdup(mnt);
-						smackfs_mnt_dirfd = fd;
-					} else {
-						/* Some other thread won the race. */
-						close(fd);
-					}
-					pthread_mutex_unlock(&smackfs_mnt_lock);
-					return 0;
-				}
+			pthread_mutex_lock(&smackfs_mnt_lock);
+			if (smackfs_mnt_dirfd == -1) {
+				smackfs_mnt = strdup(mnt);
+				smackfs_mnt_dirfd = fd;
+			} else {
+				/* Some other thread won the race. */
+				close(fd);
 			}
+			pthread_mutex_unlock(&smackfs_mnt_lock);
+			return 0;
 		}
 	}
 


### PR DESCRIPTION
Mounting the SMACKFS read-only has side effect on commands 'id', 'ls', 'ps', ... because libsmack refuses to detect SMACKFS when it is mounted read-only.

I guess that this behaviour is because many features of libsmack are expecting write permission.

The current behaviour doesn't seems to be consistent with the reality: SMACKFS is mounted and SMACK security is active. 

You can't write it? Do you have the CAP_MAC_ADMIN? Is it read-only mounted? Does function `verify_smackfs_mnt` refuse to validate the filesystem when CAP_MAC_ADMIN is off? No.
