### PR TITLE
libsmack: fix smack_new_label_from_path() (regression in e6890752)

### DIFF
--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -631,6 +631,7 @@ ssize_t smack_new_label_from_path(const char *path, const char *xattr,
 		lgetxattr(path, xattr, buf, SMACK_LABEL_LEN + 1);
 	if (ret < 0)
 		return -1;
+	buf[ret] = '\0';
 
 	result = calloc(ret + 1, 1);
 	if (result == NULL)


### PR DESCRIPTION
Function `smack_new_label_from_path` failed to null-terminate xattr value before passing it to `get_label`.
