### PR TITLE
Add functions for setting and removing labels using file descriptors.

### DIFF
--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -673,6 +673,25 @@ int smack_remove_label_for_path(const char *path,
 	return follow ? removexattr(path, xattr) : lremovexattr(path, xattr);
 }
 
+int smack_set_label_for_fd(int fd,
+				  const char *xattr,
+				  const char *label)
+{
+	int len;
+
+	len = (int)smack_label_length(label);
+	if (len < 0)
+		return -2;
+
+	return fsetxattr(fd, xattr, label, len, 0);
+}
+
+int smack_remove_label_for_fd(int fd,
+				  const char *xattr)
+{
+	return fremovexattr(fd, xattr);
+}
+
 int smack_set_label_for_self(const char *label)
 {
 	int len;

--- a/libsmack/libsmack.sym
+++ b/libsmack/libsmack.sym
@@ -28,6 +28,8 @@ global:
 	smack_label_length;
 	smack_set_label_for_path;
 	smack_remove_label_for_path;
+	smack_set_label_for_fd;
+	smack_remove_label_for_fd;
 	 smack_load_policy;
 local:
 	*;

--- a/libsmack/sys/smack.h
+++ b/libsmack/sys/smack.h
@@ -257,6 +257,29 @@ int smack_remove_label_for_path(const char *path,
 				  int follow);
 
 /*!
+  * Set the SMACK label in an extended attribute.
+  *
+  * @param fd file descriptor
+  * @param xattr the extended attribute containing the SMACK label
+  * @param label output variable for the returned label
+  * @return Returns length of the label on success and negative value
+  * on failure.
+  */
+int smack_set_label_for_fd(int fd,
+				  const char *xattr,
+				  const char *label);
+
+/*!
+  * Remove the SMACK label in an extended attribute.
+  *
+  * @param fd file descriptor
+  * @param xattr the extended attribute containing the SMACK label
+  * @return Returns 0 on success and negative on failure.
+  */
+int smack_remove_label_for_fd(int fd,
+				  const char *xattr);
+
+/*!
  * Set the label associated with the callers process. The caller must have
  * CAP_MAC_ADMIN POSIX capability in order to do this.
  *


### PR DESCRIPTION
Functions added to libsmack:
- smack_set_label_for_fd()
- smack_remove_label_for_fd()

Since libsmack does not provide any function for setting labels
on sockets and functions mentioned above are useful in general,
they should be part of libsmack 1.1 API.

Signed-off-by: Marcin Niesluchowski <m.niesluchow@samsung.com>