### PR TITLE
libsmack: fix parsing of CIPSO settings

### DIFF
--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -51,6 +51,12 @@
 #define CIPSO_MAX_SIZE CIPSO_POS(CAT_MAX_COUNT)
 #define CIPSO_NUM_LEN_STR "%-4d"
 
+#define BITMASK(b)    (1 << ((b) & 7))
+#define BITSLOT(b)    ((b) >> 3)
+#define BITSET(a, b)  ((a)[BITSLOT(b)] |= BITMASK(b))
+#define BITTEST(a, b) ((a)[BITSLOT(b)] & BITMASK(b))
+#define BITNSLOTS(nb) ((nb + 7) >> 3)
+
 #define ACCESS_TYPE_R 0x01
 #define ACCESS_TYPE_W 0x02
 #define ACCESS_TYPE_X 0x04
@@ -108,7 +114,7 @@ struct smack_accesses {
 
 struct cipso_mapping {
 	char label[SMACK_LABEL_LEN + 1];
-	int cats[CAT_MAX_COUNT];
+	uint8_t cats[BITNSLOTS(CAT_MAX_COUNT)];
 	int ncats;
 	int level;
 	struct cipso_mapping *next;
@@ -463,9 +469,11 @@ int smack_cipso_apply(struct smack_cipso *cipso)
 		sprintf(&buf[offset], CIPSO_NUM_LEN_STR, m->ncats);
 		offset += NUM_LEN;
 
-		for (i = 0; i < m->ncats; i++){
-			sprintf(&buf[offset], CIPSO_NUM_LEN_STR, m->cats[i]);
-			offset += NUM_LEN;
+		for (i = 0; i < CAT_MAX_COUNT; i++) {
+			if (BITTEST(m->cats, i)) {
+				sprintf(&buf[offset], CIPSO_NUM_LEN_STR, i + 1);
+				offset += NUM_LEN;
+			}
 		}
 
 		if (write(fd, buf, offset) < 0) {
@@ -535,12 +543,13 @@ int smack_cipso_add_from_file(struct smack_cipso *cipso, int fd)
 			if (val <= 0 || val > CAT_MAX_COUNT)
 				goto err_out;
 
-			mapping->cats[i] = val;
+			if (!BITTEST(mapping->cats, val - 1)) {
+				BITSET(mapping->cats, val - 1);
+				++(mapping->ncats);
+			}
 
 			cat = strtok_r(NULL, " \t\n", &ptr);
 		}
-
-		mapping->ncats = i;
 
 		if (cipso->first == NULL) {
 			cipso->first = cipso->last = mapping;


### PR DESCRIPTION
Adjust CIPSO parsing to expected kernel format:
- maximum number of categories is 184
- each category value must be between 1 and 184

To decrease size of struct cipso_mapping, categories are now stored in a bit array. On a i386 machine it will occupy 292 bytes instead of 1004.
