### PR TITLE
libsmack/common.c: Include <limits.h> for PATH_MAX

### DIFF
--- a/libsmack/common.c
+++ b/libsmack/common.c
@@ -22,6 +22,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
fixes compilation with musl libc.