### PR TITLE
this closes #103 issue

### DIFF
--- a/doc/chsmack.8
+++ b/doc/chsmack.8
@@ -26,7 +26,7 @@ chsmack \- Change or list the Smack properties of filesystem objects
 
 .B chsmack [-L|--dereference] [--] files...
 
-.B chsmack [-L|--dereference] [-D|--drop] props... [--] files...
+.B chsmack [-L|--dereference] props... [--] files...
 
 .B chsmack (-d|--remove) [-L|--dereference] [props]... [--] files...
 
@@ -36,7 +36,7 @@ chsmack \- Change or list the Smack properties of filesystem objects
 
 First form is used to query the Smack properties of the files.
 
-Second form is used to set some Smack properties to the files.
+Second form is used to set and reset some Smack properties to the files.
 
 Third form is used to remove all or some of the Smack properties of the
 listed files.
@@ -96,7 +96,15 @@ to read and execute the binary from the \fBapplication\fR context.
 This label is stored in the \fBsecurity.SMACK64\fR extended attribute.
 
 .TP
+.B -A, --drop-access
 
+Drop the \fIaccess\fR property attached to the file.
+
+After that operation, the \fIaccess\fR property for the file
+will be the default access property set during the file system
+mounting or \fB_\fR if none.
+
+.TP
 .B -e, --exec \fR[label]
 
 If removing properties (option \fB-d\fR), no label must be set.
@@ -109,7 +117,11 @@ it will be launched in.
 This label is stored in the \fBsecurity.SMACK64EXEC\fR extended attribute.
 
 .TP
+.B -E, --drop-exec
 
+Drop the \fIexec\fR property attached to the file.
+
+.TP
 .B -m, --mmap \fR[label]
 
 If removing properties (option \fB-d\fR), no label must be set.
@@ -123,7 +135,11 @@ access to.
 This label is stored in the \fBsecurity.SMACK64MMAP\fR extended attribute.
 
 .TP
+.B -M, --drop-mmap
 
+Drop the \fImmap\fR property attached to the file.
+
+.TP
 .B -t, --transmute
 
 When used this will set the transmute flag of a directory to True.
@@ -138,6 +154,11 @@ Each of the text editors can open the files and edit them in a shared fashion,
 while still ensuring that the config files of the editor remain protected.
 
 This label is stored in the \fBsecurity.SMACK64TRANSMUTE\fR extended attribute.
+
+.TP
+.B -T, --drop-transmute
+
+Drop the \fItransmute\fR property attached to the file.
 
 .TP
 .B -D, --drop
@@ -188,6 +209,13 @@ chsmack -aUser -D file1 file2
 
 This command set the Smack \fIaccess\fR property to \fIUser\fR and
 drop any other Smack properties for the files \fIfile1\fR and \fIfile2\fR.
+
+.EX
+chsmack -E -a Nobody file3
+.EE
+
+This command set the Smack \fIaccess\fR property to \fINobody\fR and
+drops the \fIexec\fR property for the file \fIfile3\fR.
 
 .SH "SEE ALSO"
 

--- a/doc/chsmack.8
+++ b/doc/chsmack.8
@@ -28,7 +28,7 @@ chsmack \- Change or list the Smack properties of filesystem objects
 
 .B chsmack [-L|--dereference] props... [--] files...
 
-.B chsmack (-d|--remove) [-L|--dereference] [props]... [--] files...
+chsmack (-d|--remove) [-L|--dereference] [props]... [--] files...
 
 .SH DESCRIPTION
 
@@ -40,6 +40,7 @@ Second form is used to set and reset some Smack properties to the files.
 
 Third form is used to remove all or some of the Smack properties of the
 listed files.
+\fBThis third form is now obsolete, use second form instead.\fR
 
 Depending on the state and type of the file the different labels,
 which are stored as extended attributes, have a different effect.
@@ -66,20 +67,9 @@ Use this option to process the target of the symbolic links instead of the
 symbolic links themselves.
 
 .TP
-.B -d, --remove
+.B -a, --access \fRlabel
 
-Use this option to remove the smack properties of the files.
-You specify the properties to remove using options \fB-a\fR, \fB-e\fR,
-\fB-m\fR or \fB-t\fR (or their long version) without putting their label
-value.
-If no property is specified, it means that all the properties will
-be removed.
-
-.TP
-.B -a, --access \fR[label]
-
-If removing properties (option \fB-d\fR), no label must be set.
-Otherwise, when setting, the label must be set and its value must be a valid
+When setting, the label must be set and its value must be a valid
 Smack label.
 
 This context is used to confine the access modes, which are defined by the
@@ -105,10 +95,9 @@ will be the default access property set during the file system
 mounting or \fB_\fR if none.
 
 .TP
-.B -e, --exec \fR[label]
+.B -e, --exec \fRlabel
 
-If removing properties (option \fB-d\fR), no label must be set.
-Otherwise, when setting, the label must be set and its value must be a valid
+When setting, the label must be set and its value must be a valid
 Smack label.
 
 If this file is an application binary, this flag defines the context that
@@ -122,10 +111,9 @@ This label is stored in the \fBsecurity.SMACK64EXEC\fR extended attribute.
 Drop the \fIexec\fR property attached to the file.
 
 .TP
-.B -m, --mmap \fR[label]
+.B -m, --mmap \fRlabel
 
-If removing properties (option \fB-d\fR), no label must be set.
-Otherwise, when setting, the label must be set and its value must be a valid
+When setting, the label must be set and its value must be a valid
 Smack label.
 
 A file with the mmap attribute set can only be mapped by processes with
@@ -164,6 +152,20 @@ Drop the \fItransmute\fR property attached to the file.
 .B -D, --drop
 
 Use this option to remove the smack properties that are not set for files.
+If no property is specified, it means that all the properties will
+be removed.
+
+.SH OBSOLETE OPTIONS
+
+.TP
+.B -d, --remove
+
+\fBThis option is obsolete, use -D, -A, -M -E, -T instead.\fR
+
+Use this option to remove the smack properties of the files.
+You specify the properties to remove using options \fB-a\fR, \fB-e\fR,
+\fB-m\fR or \fB-t\fR (or their long version) without putting their label
+value.
 If no property is specified, it means that all the properties will
 be removed.
 

--- a/doc/chsmack.8
+++ b/doc/chsmack.8
@@ -151,7 +151,9 @@ Drop the \fItransmute\fR property attached to the file.
 .TP
 .B -D, --drop
 
-Use this option to remove the smack properties that are not set for files.
+Use this option to instruct chsmack to remove all attributes that aren't set by other flags.
+For example chsmack -a Foo -D would drop all attributes except security.SMACK64.
+
 If no property is specified, it means that all the properties will
 be removed.
 

--- a/doc/chsmack.8
+++ b/doc/chsmack.8
@@ -26,7 +26,7 @@ chsmack \- Change or list the Smack properties of filesystem objects
 
 .B chsmack [-L|--dereference] [--] files...
 
-.B chsmack [-L|--dereference] props... [--] files...
+.B chsmack [-L|--dereference] [-D|--drop] props... [--] files...
 
 .B chsmack (-d|--remove) [-L|--dereference] [props]... [--] files...
 
@@ -139,6 +139,13 @@ while still ensuring that the config files of the editor remain protected.
 
 This label is stored in the \fBsecurity.SMACK64TRANSMUTE\fR extended attribute.
 
+.TP
+.B -D, --drop
+
+Use this option to remove the smack properties that are not set for files.
+If no property is specified, it means that all the properties will
+be removed.
+
 .SH RETURN VALUE
 
 The current values for the labels will be printed to stdout on success.
@@ -171,6 +178,16 @@ There are some predefined labels:
 
 -	\fB@\fR 	Pronounced "web", a single at sign character.
 
+.SH EXAMPLES
+
+Here are some examples that may be useful.
+
+.EX
+chsmack -aUser -D file1 file2
+.EE
+
+This command set the Smack \fIaccess\fR property to \fIUser\fR and
+drop any other Smack properties for the files \fIfile1\fR and \fIfile2\fR.
 
 .SH "SEE ALSO"
 

--- a/doc/chsmack.8
+++ b/doc/chsmack.8
@@ -24,11 +24,11 @@ chsmack \- Change or list the Smack properties of filesystem objects
 
 .SH SYNOPSIS 
 
-.B chsmack [-L|--dereference] [--] files...
+.B chsmack [-L] [-r] [--] files...
 
-.B chsmack [-L|--dereference] props... [--] files...
+.B chsmack [-L] [-r] props... [--] files...
 
-chsmack (-d|--remove) [-L|--dereference] [props]... [--] files...
+chsmack -d [-L] [-r] [props]... [--] files...
 
 .SH DESCRIPTION
 
@@ -154,6 +154,12 @@ Drop the \fItransmute\fR property attached to the file.
 Use this option to remove the smack properties that are not set for files.
 If no property is specified, it means that all the properties will
 be removed.
+
+.TP
+.B -r, --recursive
+
+Use this option to list or modify files in subdirectories.
+It follows symbolic links only if in the command line.
 
 .SH OBSOLETE OPTIONS
 

--- a/utils/chsmack.c
+++ b/utils/chsmack.c
@@ -111,7 +111,7 @@ static void modify_prop(const char *path, struct labelset *ls, const char *attr)
 	switch (ls->isset) {
 	case positive:
 		rc = smack_set_label_for_path(path, attr, follow_flag,
-								ls->value);
+					      ls->value);
 		if (rc < 0)
 			perror(path);
 		break;
@@ -139,17 +139,18 @@ static void modify_transmute(const char *path)
 					"%s: transmute: not a directory\n",
 					path);
 			}
-		}
-		else {
+		} else {
 			rc = smack_set_label_for_path(path,
-				XATTR_NAME_SMACKTRANSMUTE, follow_flag, "TRUE");
+						      XATTR_NAME_SMACKTRANSMUTE,
+						      follow_flag, "TRUE");
 			if (rc < 0)
 				perror(path);
 		}
 		break;
 	case negative:
 		rc = smack_remove_label_for_path(path,
-					XATTR_NAME_SMACKTRANSMUTE, follow_flag);
+						 XATTR_NAME_SMACKTRANSMUTE,
+						 follow_flag);
 		if (rc < 0 && errno != ENODATA)
 			perror(path);
 		break;
@@ -177,7 +178,8 @@ static void print_file(const char *path)
 
 	errno = 0;
 	rc = (int)smack_new_label_from_path(path,
-		XATTR_NAME_SMACK, follow_flag, &label);
+					    XATTR_NAME_SMACK, follow_flag,
+					    &label);
 	if (rc > 0) {
 		printf(" access=\"%s\"", label);
 		free(label);
@@ -185,7 +187,8 @@ static void print_file(const char *path)
 	}
 
 	rc = (int)smack_new_label_from_path(path,
-		XATTR_NAME_SMACKEXEC, follow_flag, &label);
+					    XATTR_NAME_SMACKEXEC, follow_flag,
+					    &label);
 	if (rc > 0) {
 		printf(" execute=\"%s\"", label);
 		free(label);
@@ -193,7 +196,8 @@ static void print_file(const char *path)
 	}
 
 	rc = (int)smack_new_label_from_path(path,
-		XATTR_NAME_SMACKMMAP, follow_flag, &label);
+					    XATTR_NAME_SMACKMMAP, follow_flag,
+					    &label);
 	if (rc > 0) {
 		printf(" mmap=\"%s\"", label);
 		free(label);
@@ -201,7 +205,8 @@ static void print_file(const char *path)
 	}
 
 	rc = (int)smack_new_label_from_path(path,
-		XATTR_NAME_SMACKTRANSMUTE, follow_flag, &label);
+					    XATTR_NAME_SMACKTRANSMUTE,
+					    follow_flag, &label);
 	if (rc > 0) {
 		printf(" transmute=\"%s\"", label);
 		free(label);
@@ -250,7 +255,7 @@ static void explore(const char *path, void (*fun)(const char*), int follow)
 		memcpy(file, path, last);
 		file[last++] = '/';
 	}
-	for(;;) {
+	for (;;) {
 		rc = readdir_r(dir, &dent, &pent);
 		if (rc != 0 || pent == NULL) {
 			free(file);
@@ -259,7 +264,7 @@ static void explore(const char *path, void (*fun)(const char*), int follow)
 		}
 		l = strlen(dent.d_name);
 		if (l && dent.d_name[0] == '.'
-			&& (l == 1 || l == 2 && dent.d_name[1] == '.'))
+		    && (l == 1 || l == 2 && dent.d_name[1] == '.'))
 			continue;
 		if (last + l >= length) {
 			file = realloc(file, last + l + 20);
@@ -287,8 +292,7 @@ static void set_state(enum state *to, enum state value, int car, int fatal)
 			option_by_char(car)->name, option_by_char(car)->val);
 		if (fatal)
 			exit(1);
-	}
-	else {
+	} else {
 		fprintf(stderr, "error, option --%s or -%c opposite to an "
 			"option already set.\n",
 			option_by_char(car)->name, option_by_char(car)->val);
@@ -313,57 +317,56 @@ int main(int argc, char *argv[])
 	while ((c = getopt_long(argc, argv, shortoptions, options, NULL)) != -1) {
 
 		switch (c) {
-			case 'a':
-			case 'e':
-			case 'm':
-				/* greedy on optional arguments */
-				if (optarg == NULL && argv[optind] != NULL 
-						&& argv[optind][0] != '-') {
-					optind++;
-				}
-				break;
-			case 'A':
-				set_state(&access_set.isset, negative, c, 0);
-				modify = 1;
-				break;
-			case 'E':
-				set_state(&exec_set.isset, negative, c, 0);
-				modify = 1;
-				break;
-			case 'M':
-				set_state(&mmap_set.isset, negative, c, 0);
-				modify = 1;
-				break;
-			case 'T':
-				set_state(&transmute_flag, negative, c, 0);
-				modify = 1;
-				break;
-			case 't':
-				break;
-			case 'd':
-				set_state(&delete_flag, positive, c, 0);
-				fprintf(stderr, 
-					"remove: option -d is obsolete!\n");
-				break;
-			case 'D':
-				set_state(&delete_flag, negative, c, 0);
-				break;
-			case 'L':
-				set_state(&follow_flag, positive, c, 0);
-				break;
-			case 'r':
-				set_state(&recursive_flag, positive, c, 0);
-				break;
-			case 'v':
-				printf("%s (libsmack) version " PACKAGE_VERSION "\n",
-				       basename(argv[0]));
-				exit(0);
-			case 'h':
-				printf(usage, basename(argv[0]));
-				exit(0);
-			default:
-				printf(usage, basename(argv[0]));
-				exit(1);
+		case 'a':
+		case 'e':
+		case 'm':
+			/* greedy on optional arguments */
+			if (optarg == NULL && argv[optind] != NULL
+			    && argv[optind][0] != '-') {
+				optind++;
+			}
+			break;
+		case 'A':
+			set_state(&access_set.isset, negative, c, 0);
+			modify = 1;
+			break;
+		case 'E':
+			set_state(&exec_set.isset, negative, c, 0);
+			modify = 1;
+			break;
+		case 'M':
+			set_state(&mmap_set.isset, negative, c, 0);
+			modify = 1;
+			break;
+		case 'T':
+			set_state(&transmute_flag, negative, c, 0);
+			modify = 1;
+			break;
+		case 't':
+			break;
+		case 'd':
+			set_state(&delete_flag, positive, c, 0);
+			fprintf(stderr, "remove: option -d is obsolete!\n");
+			break;
+		case 'D':
+			set_state(&delete_flag, negative, c, 0);
+			break;
+		case 'L':
+			set_state(&follow_flag, positive, c, 0);
+			break;
+		case 'r':
+			set_state(&recursive_flag, positive, c, 0);
+			break;
+		case 'v':
+			printf("%s (libsmack) version " PACKAGE_VERSION "\n",
+			       basename(argv[0]));
+			exit(0);
+		case 'h':
+			printf(usage, basename(argv[0]));
+			exit(0);
+		default:
+			printf(usage, basename(argv[0]));
+			exit(1);
 		}
 	}
 
@@ -373,48 +376,46 @@ int main(int argc, char *argv[])
 	while ((c = getopt_long(argc, argv, shortoptions, options, NULL)) != -1) {
 
 		switch (c) {
-			case 'a':
-				labelset = &access_set;
-				break;
-			case 'e':
-				labelset = &exec_set;
-				break;
-			case 'm':
-				labelset = &mmap_set;
-				break;
-			case 't':
-				set_state(&transmute_flag, svalue, c, 0);
-				modify = 1;
-			default:
-				continue;
+		case 'a':
+			labelset = &access_set;
+			break;
+		case 'e':
+			labelset = &exec_set;
+			break;
+		case 'm':
+			labelset = &mmap_set;
+			break;
+		case 't':
+			set_state(&transmute_flag, svalue, c, 0);
+			modify = 1;
+		default:
+			continue;
 		}
 
 		/* greedy on optional arguments */
 		if (optarg == NULL && argv[optind] != NULL
-						&& argv[optind][0] != '-') {
+		    && argv[optind][0] != '-') {
 			optarg = argv[optind++];
 		}
 		if (optarg == NULL) {
 			if (delete_flag != positive) {
 				fprintf(stderr, "%s: require a label on set.\n",
-						option_by_char(c)->name);
+					option_by_char(c)->name);
 				exit(1);
 			}
-		}
-		else if (delete_flag == positive) {
+		} else if (delete_flag == positive) {
 			fprintf(stderr, "%s: require no label on delete.\n",
-						option_by_char(c)->name);
+				option_by_char(c)->name);
 			exit(1);
-		}
-		else if (strnlen(optarg, SMACK_LABEL_LEN + 1) == SMACK_LABEL_LEN + 1) {
+		} else if (strnlen(optarg, SMACK_LABEL_LEN + 1) ==
+			   SMACK_LABEL_LEN + 1) {
 			fprintf(stderr, "%s: \"%s\" exceeds %d characters.\n",
-					option_by_char(c)->name, optarg,
-					SMACK_LABEL_LEN);
+				option_by_char(c)->name, optarg,
+				SMACK_LABEL_LEN);
 			exit(1);
-		}
-		else if (smack_label_length(optarg) < 0) {
+		} else if (smack_label_length(optarg) < 0) {
 			fprintf(stderr, "%s: invalid Smack label '%s'.\n",
-					option_by_char(c)->name, optarg);
+				option_by_char(c)->name, optarg);
 			exit(1);
 		}
 
@@ -434,8 +435,7 @@ int main(int argc, char *argv[])
 			mmap_set.isset = negative;
 		if (transmute_flag == unset)
 			transmute_flag = negative;
-	}
-	else if (delete_flag == positive && !modify) {
+	} else if (delete_flag == positive && !modify) {
 		access_set.isset = negative;
 		exec_set.isset = negative;
 		mmap_set.isset = negative;
@@ -447,8 +447,7 @@ int main(int argc, char *argv[])
 	fun = modify ? modify_file : print_file;
 	if (optind == argc) {
 		explore(NULL, fun, 0);
-	}
-	else {
+	} else {
 		for (i = optind; i < argc; i++) {
 			fun(argv[i]);
 			if (recursive_flag)

--- a/utils/chsmack.c
+++ b/utils/chsmack.c
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
 	int delete_flag = 0;
 	int follow_flag = 0;
 	enum state transmute_flag = unset;
-	int option_flag = 0;
+	int modify = 0;
 	int rc;
 	int c;
 	int i;
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
 					fprintf(stderr, "%s: %s: option set many times.\n",
 							basename(argv[0]), option_by_char(c)->name);
 				transmute_flag = positive;
-				option_flag = 1;
+				modify = 1;
 				break;
 			case 'd':
 				if (delete_flag)
@@ -199,16 +199,18 @@ int main(int argc, char *argv[])
 		}
 		labelset->isset = delete_flag ? negative : positive;
 		labelset->value = optarg;
-		option_flag = 1;
+		modify = 1;
 	}
 
-	/* deleting labels */
-	if (delete_flag && !option_flag) {
+	/* update states */
+	if (delete_flag && !modify) {
 		access_set.isset = negative;
 		exec_set.isset = negative;
 		mmap_set.isset = negative;
 		transmute_flag = negative;
 	}
+
+	/* deleting labels */
 	if (delete_flag) {
 		for (i = optind; i < argc; i++) {
 			if (access_set.isset != unset) {
@@ -242,7 +244,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* setting labels */
-	else if (option_flag) {
+	else if (modify) {
 		for (i = optind; i < argc; i++) {
 			if (access_set.isset != unset) {
 				rc = smack_set_label_for_path(argv[i],

--- a/utils/chsmack.c
+++ b/utils/chsmack.c
@@ -37,18 +37,22 @@
 static const char usage[] =
 	"Usage: %s [options] <path>\n"
 	"options:\n"  
-	" -v --version       output version information and exit\n"
-	" -h --help          output usage information and exit\n"
-	" -a --access        set/remove "XATTR_NAME_SMACK"\n"  
-	" -e --exec          set/remove "XATTR_NAME_SMACKEXEC"\n"  
-	" -m --mmap          set/remove "XATTR_NAME_SMACKMMAP"\n"  
-	" -t --transmute     set/remove "XATTR_NAME_SMACKTRANSMUTE"\n"
-	" -d --remove        tell to remove the attribute\n"
-	" -L --dereference   tell to follow the symbolic links\n"
-	" -D --drop          remove unset attributes\n"
+	" -v --version         output version information and exit\n"
+	" -h --help            output usage information and exit\n"
+	" -a --access          set/remove "XATTR_NAME_SMACK"\n"
+	" -e --exec            set/remove "XATTR_NAME_SMACKEXEC"\n"
+	" -m --mmap            set/remove "XATTR_NAME_SMACKMMAP"\n"
+	" -t --transmute       set/remove "XATTR_NAME_SMACKTRANSMUTE"\n"
+	" -d --remove          tell to remove the attribute\n"
+	" -L --dereference     tell to follow the symbolic links\n"
+	" -D --drop            remove unset attributes\n"
+	" -A --drop-access     remove "XATTR_NAME_SMACK"\n"
+	" -E --drop-exec       remove "XATTR_NAME_SMACKEXEC"\n"
+	" -M --drop-mmap       remove "XATTR_NAME_SMACKMMAP"\n"
+	" -T --drop-transmute  remove "XATTR_NAME_SMACKTRANSMUTE"\n"
 ;
 
-static const char shortoptions[] = "vha::e::m::tdLD";
+static const char shortoptions[] = "vha::e::m::tdLDAEMT";
 static struct option options[] = {
 	{"version", no_argument, 0, 'v'},
 	{"help", no_argument, 0, 'h'},
@@ -58,6 +62,10 @@ static struct option options[] = {
 	{"transmute", no_argument, 0, 't'},
 	{"dereference", no_argument, 0, 'L'},
 	{"drop", no_argument, 0, 'D'},
+	{"drop-access", no_argument, 0, 'A'},
+	{"drop-exec", no_argument, 0, 'E'},
+	{"drop-mmap", no_argument, 0, 'M'},
+	{"drop-transmute", no_argument, 0, 'T'},
 	{"remove", no_argument, 0, 'd'},
 	{NULL, 0, 0, 0}
 };
@@ -163,6 +171,34 @@ int main(int argc, char *argv[])
 						&& argv[optind][0] != '-') {
 					optind++;
 				}
+				break;
+			case 'A':
+				if (access_set.isset != unset)
+					fprintf(stderr, "%s: %s: option set many times.\n",
+							basename(argv[0]), option_by_char(c)->name);
+				access_set.isset = negative;
+				modify = 1;
+				break;
+			case 'E':
+				if (exec_set.isset != unset)
+					fprintf(stderr, "%s: %s: option set many times.\n",
+							basename(argv[0]), option_by_char(c)->name);
+				exec_set.isset = negative;
+				modify = 1;
+				break;
+			case 'M':
+				if (mmap_set.isset != unset)
+					fprintf(stderr, "%s: %s: option set many times.\n",
+							basename(argv[0]), option_by_char(c)->name);
+				mmap_set.isset = negative;
+				modify = 1;
+				break;
+			case 'T':
+				if (transmute_flag != unset)
+					fprintf(stderr, "%s: %s: option set many times.\n",
+							basename(argv[0]), option_by_char(c)->name);
+				transmute_flag = negative;
+				modify = 1;
 				break;
 			case 't':
 				if (transmute_flag != unset)

--- a/utils/chsmack.c
+++ b/utils/chsmack.c
@@ -212,28 +212,28 @@ int main(int argc, char *argv[])
 			if (access_set.isset != unset) {
 				rc = smack_remove_label_for_path(argv[i],
 							XATTR_NAME_SMACK, follow_flag);
-				if (rc < 0 && (option_flag || errno != ENODATA))
+				if (rc < 0 && errno != ENODATA)
 					perror(argv[i]);
 			}
 
 			if (exec_set.isset != unset) {
 				rc = smack_remove_label_for_path(argv[i],
 							XATTR_NAME_SMACKEXEC, follow_flag);
-				if (rc < 0 && (option_flag || errno != ENODATA))
+				if (rc < 0 && errno != ENODATA)
 					perror(argv[i]);
 			}
 
 			if (mmap_set.isset != unset) {
 				rc = smack_remove_label_for_path(argv[i],
 							XATTR_NAME_SMACKMMAP, follow_flag);
-				if (rc < 0 && (option_flag || errno != ENODATA))
+				if (rc < 0 && errno != ENODATA)
 					perror(argv[i]);
 			}
 
 			if (transmute_flag) {
 				rc = smack_remove_label_for_path(argv[i],
 							XATTR_NAME_SMACKTRANSMUTE, follow_flag);
-				if (rc < 0 && (option_flag || errno != ENODATA))
+				if (rc < 0 && errno != ENODATA)
 					perror(argv[i]);
 			}
 		}

--- a/utils/chsmack.c
+++ b/utils/chsmack.c
@@ -267,6 +267,8 @@ int main(int argc, char *argv[])
 				break;
 			case 'd':
 				set_state(&delete_flag, positive, c, 0);
+				fprintf(stderr, 
+					"remove: option -d is obsolete!\n");
 				break;
 			case 'D':
 				set_state(&delete_flag, negative, c, 0);

--- a/utils/chsmack.c
+++ b/utils/chsmack.c
@@ -32,6 +32,8 @@
 #include <getopt.h>
 #include <errno.h>
 #include <libgen.h>
+#include <dirent.h>
+
 #include "config.h"
 
 static const char usage[] =
@@ -39,21 +41,22 @@ static const char usage[] =
 	"Options:\n"  
 	" -v --version         output version information and exit\n"
 	" -h --help            output usage information and exit\n"
-	" -a --access          set/remove "XATTR_NAME_SMACK"\n"
-	" -e --exec            set/remove "XATTR_NAME_SMACKEXEC"\n"
-	" -m --mmap            set/remove "XATTR_NAME_SMACKMMAP"\n"
-	" -t --transmute       set/remove "XATTR_NAME_SMACKTRANSMUTE"\n"
+	" -a --access          set "XATTR_NAME_SMACK"\n"
+	" -e --exec            set "XATTR_NAME_SMACKEXEC"\n"
+	" -m --mmap            set "XATTR_NAME_SMACKMMAP"\n"
+	" -t --transmute       set "XATTR_NAME_SMACKTRANSMUTE"\n"
 	" -L --dereference     tell to follow the symbolic links\n"
 	" -D --drop            remove unset attributes\n"
 	" -A --drop-access     remove "XATTR_NAME_SMACK"\n"
 	" -E --drop-exec       remove "XATTR_NAME_SMACKEXEC"\n"
 	" -M --drop-mmap       remove "XATTR_NAME_SMACKMMAP"\n"
 	" -T --drop-transmute  remove "XATTR_NAME_SMACKTRANSMUTE"\n"
+	" -r --recursive       list or modify also files in subdirectories\n"
 	"Obsolete option:\n"
 	" -d --remove          tell to remove the attribute\n"
 ;
 
-static const char shortoptions[] = "vha::e::m::tdLDAEMT";
+static const char shortoptions[] = "vha::e::m::tdLDAEMTr";
 static struct option options[] = {
 	{"version", no_argument, 0, 'v'},
 	{"help", no_argument, 0, 'h'},
@@ -67,6 +70,7 @@ static struct option options[] = {
 	{"drop-exec", no_argument, 0, 'E'},
 	{"drop-mmap", no_argument, 0, 'M'},
 	{"drop-transmute", no_argument, 0, 'T'},
+	{"recursive", no_argument, 0, 'r'},
 	{"remove", no_argument, 0, 'd'},
 	{NULL, 0, 0, 0}
 };
@@ -89,6 +93,7 @@ static struct labelset exec_set = { unset, NULL }; /* for option "exec" */
 static struct labelset mmap_set = { unset, NULL }; /* for option "mmap" */
 static enum state transmute_flag = unset; /* for option "transmute" */
 static enum state follow_flag = unset; /* for option "dereference" */
+static enum state recursive_flag = unset; /* for option "recursive" */
 
 /* get the option for the given char */
 static struct option *option_by_char(int car)
@@ -125,12 +130,15 @@ static void modify_transmute(const char *path)
 	int rc;
 	switch (transmute_flag) {
 	case positive:
-		rc = follow_flag ?  stat(path, &st) : lstat(path, &st);
+		rc = follow_flag ? stat(path, &st) : lstat(path, &st);
 		if (rc < 0)
 			perror(path);
 		else if (!S_ISDIR(st.st_mode)) {
-			fprintf(stderr, "%s: transmute: not a directory\n",
-				path);
+			if (!recursive_flag) {
+				fprintf(stderr,
+					"%s: transmute: not a directory\n",
+					path);
+			}
 		}
 		else {
 			rc = smack_set_label_for_path(path,
@@ -162,6 +170,7 @@ static void print_file(const char *path)
 {
 	int rc;
 	char *label;
+	int n = 0;
 
 	/* Print file path. */
 	printf("%s", path);
@@ -172,9 +181,7 @@ static void print_file(const char *path)
 	if (rc > 0) {
 		printf(" access=\"%s\"", label);
 		free(label);
-	}
-	else if (errno != 0) {
-		printf(": %s", strerror(errno));
+		n = 1;
 	}
 
 	rc = (int)smack_new_label_from_path(path,
@@ -182,6 +189,7 @@ static void print_file(const char *path)
 	if (rc > 0) {
 		printf(" execute=\"%s\"", label);
 		free(label);
+		n = 1;
 	}
 
 	rc = (int)smack_new_label_from_path(path,
@@ -189,6 +197,7 @@ static void print_file(const char *path)
 	if (rc > 0) {
 		printf(" mmap=\"%s\"", label);
 		free(label);
+		n = 1;
 	}
 
 	rc = (int)smack_new_label_from_path(path,
@@ -196,9 +205,75 @@ static void print_file(const char *path)
 	if (rc > 0) {
 		printf(" transmute=\"%s\"", label);
 		free(label);
+		n = 1;
 	}
 
-	printf("\n");
+	printf(n ? "\n" : ": No smack property found\n");
+}
+
+static void explore(const char *path, void (*fun)(const char*), int follow)
+{
+	struct stat st;
+	int rc;
+	char *file;
+	size_t last, length, l;
+	DIR *dir;
+	struct dirent dent, *pent;
+
+	/* type of the path */
+	rc = (follow ? stat : lstat)(path ? path : ".", &st);
+	if (rc < 0) {
+		perror(path);
+		return;
+	}
+
+	/* no a directory, skip */
+	if (!S_ISDIR(st.st_mode))
+		return;
+
+	/* open the directory */
+	dir = opendir(path ? path : ".");
+	if (dir == NULL) {
+		perror(path);
+		return;
+	}
+
+	/* iterate ove the directory's entries */
+	last = path ? strlen(path) : 0;
+	length = last + 100;
+	file = malloc(length);
+	if (file == NULL) {
+		fprintf(stderr, "error: out of memory.\n");
+		exit(1);
+	}
+	if (last != 0) {
+		memcpy(file, path, last);
+		file[last++] = '/';
+	}
+	for(;;) {
+		rc = readdir_r(dir, &dent, &pent);
+		if (rc != 0 || pent == NULL) {
+			free(file);
+			closedir(dir);
+			return;
+		}
+		l = strlen(dent.d_name);
+		if (l && dent.d_name[0] == '.'
+			&& (l == 1 || l == 2 && dent.d_name[1] == '.'))
+			continue;
+		if (last + l >= length) {
+			file = realloc(file, last + l + 20);
+			if (file == NULL) {
+				fprintf(stderr, "error: out of memory.\n");
+				exit(1);
+			}
+			length = last + l + 20;
+		}
+		memcpy(file + last, dent.d_name, l + 1);
+		fun(file);
+		if (recursive_flag)
+			explore(file, fun, 0);
+	}
 }
 
 /* set the state to to */
@@ -275,6 +350,9 @@ int main(int argc, char *argv[])
 				break;
 			case 'L':
 				set_state(&follow_flag, positive, c, 0);
+				break;
+			case 'r':
+				set_state(&recursive_flag, positive, c, 0);
 				break;
 			case 'v':
 				printf("%s (libsmack) version " PACKAGE_VERSION "\n",
@@ -367,7 +445,15 @@ int main(int argc, char *argv[])
 
 	/* process */
 	fun = modify ? modify_file : print_file;
-	for (i = optind; i < argc; i++)
-		fun(argv[i]);
+	if (optind == argc) {
+		explore(NULL, fun, 0);
+	}
+	else {
+		for (i = optind; i < argc; i++) {
+			fun(argv[i]);
+			if (recursive_flag)
+				explore(argv[i], fun, 1);
+		}
+	}
 	exit(0);
 }


### PR DESCRIPTION
This closes #103 issue.

This implements recursion for chsmack and also improves how to delete smack properties.

Briefly, it is now possible to set properties while resetting other properties in the same time.

Example:

    chsmack -a User -T dir

set the label of the directory 'dir' and remove its transmute property (if any)