### PR TITLE
Add smack_set_onlycap API & its usage in smack_load_policy()

### DIFF
--- a/libsmack/common.c
+++ b/libsmack/common.c
@@ -24,6 +24,7 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>

--- a/libsmack/common.h
+++ b/libsmack/common.h
@@ -23,6 +23,7 @@
 
 #define ACCESSES_D_PATH "/etc/smack/accesses.d"
 #define CIPSO_D_PATH "/etc/smack/cipso.d"
+#define ONLYCAP_PATH "/etc/smack/onlycap"
 
 int clear(void);
 int apply_rules(const char *path, int clear);

--- a/libsmack/libsmack.sym
+++ b/libsmack/libsmack.sym
@@ -38,3 +38,9 @@ LIBSMACK_1.2 {
 global:
 	smack_set_relabel_self;
 } LIBSMACK_1.1;
+
+LIBSMACK_1.3 {
+global:
+	smack_set_onlycap;
+	smack_set_onlycap_from_file;
+} LIBSMACK_1.2;

--- a/libsmack/sys/smack.h
+++ b/libsmack/sys/smack.h
@@ -322,6 +322,7 @@ ssize_t smack_label_length(const char *label);
  * This function loads the Smack policy from default location and loads
  * it to kernel. Smackfs file system must be alreadt mounted.
  * It is designed for init process to load the policy at system startup.
+ * It also sets up CIPSO and onlycap list of labels.
  *
  * @return Returns 0 on success and negative on failure.
  */
@@ -339,6 +340,34 @@ int smack_load_policy(void);
  * @return Returns 0 on success and negative on failure.
  */
 int smack_set_relabel_self(const char **labels, int cnt);
+
+/*!
+ * Set the list of labels that will be allowed to have effective CAP_MAC_ADMIN
+ * and CAP_MAC_OVERRIDE. This set of labels will be applied (written)
+ * to the kernel interface "onlycap". Setting empty list causes CAP_MAC_ADMIN &
+ * CAP_MAC_OVERRIDE to be unconstrained by any specific Smack label. Empty
+ * list of onlycap Smack labels is the default kernel configuration. The caller
+ * must have CAP_MAC_ADMIN capability. Caller may effectively loose
+ * the capability after successfull return from the function if its Smack label
+ * is not on the list of labels.
+ *
+ * @param labels list of labels (NULL for empty list)
+ * @param cnt number of labels (0 for empty list)
+ * @return Returns 0 on success and negative value on failure
+ *
+ */
+int smack_set_onlycap(const char **labels, int cnt);
+
+
+/*!
+ * Set the list of labels that will be allowed to have effective CAP_MAC_ADMIN
+ * and CAP_MAC_OVERRIDE. This function reads list of labels from file path
+ * passed as argument and calls smack_set_onlycap afterwards.
+ *
+ * @param path path to file containing list of onlycap Smack labels
+ * @return Returns 0 on success and negativ value on failure
+ */
+int smack_set_onlycap_from_file(const char* path);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
smack_set_onlycap applies the list of supplied labels to kernel.
Its usage in smack_load_policy() searches for the text file
with list of labels in /etc/smack/onlycap (each label
in separate line).