### PR TITLE
Unify smack function behaviour and fix description in headers.

### DIFF
--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -688,16 +688,14 @@ int smack_set_label_for_path(const char *path,
 				  const char *label)
 {
 	int len;
-	int ret;
 
 	len = (int)smack_label_length(label);
 	if (len < 0)
 		return -2;
 
-	ret = follow ?
+	return follow ?
 		setxattr(path, xattr, label, len, 0) :
 		lsetxattr(path, xattr, label, len, 0);
-	return ret;
 }
 
 int smack_set_label_for_file(int fd,
@@ -705,14 +703,12 @@ int smack_set_label_for_file(int fd,
 				  const char *label)
 {
 	int len;
-	int ret;
 
 	len = (int)smack_label_length(label);
 	if (len < 0)
 		return -2;
 
-	ret = fsetxattr(fd, xattr, label, len, 0);
-	return ret;
+	return fsetxattr(fd, xattr, label, len, 0);
 }
 
 int smack_remove_label_for_path(const char *path,

--- a/libsmack/sys/smack.h
+++ b/libsmack/sys/smack.h
@@ -250,8 +250,7 @@ ssize_t smack_new_label_from_file(int fd,
   * @param xattr the extended attribute containing the SMACK label
   * @param follow whether or not to follow symbolic link
   * @param label output variable for the returned label
-  * @return Returns length of the label on success and negative value
-  * on failure.
+  * @return Returns 0 on success and negative value on failure.
   */
 int smack_set_label_for_path(const char *path,
 				  const char *xattr,
@@ -264,8 +263,7 @@ int smack_set_label_for_path(const char *path,
   * @param fd opened file descriptor of the file
   * @param xattr the extended attribute containing the SMACK label
   * @param label output variable for the returned label
-  * @return Returns length of the label on success and negative value
-  * on failure.
+  * @return Returns 0 on success and negative value on failure.
   */
 int smack_set_label_for_file(int fd,
 				  const char *xattr,


### PR DESCRIPTION
Before this commit some smack functions were counting last byte of string ('\0') into the size of smack label. After this commit smack function will return size of smack label without last byte '\0'.