### PR TITLE
Add smack_set_onlycap, smack_set_onlycap_from_file APIs

### DIFF
--- a/libsmack/common.c
+++ b/libsmack/common.c
@@ -24,6 +24,7 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/stat.h>

--- a/libsmack/common.h
+++ b/libsmack/common.h
@@ -23,6 +23,7 @@
 
 #define ACCESSES_D_PATH "/etc/smack/accesses.d"
 #define CIPSO_D_PATH "/etc/smack/cipso.d"
+#define ONLYCAP_PATH "/etc/smack/onlycap"
 
 int clear(void);
 int apply_rules(const char *path, int clear);

--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -1193,6 +1193,18 @@ int smack_load_policy(void)
 	if (apply_cipso(CIPSO_D_PATH))
 		return -1;
 
+
+	int fd = open(ONLYCAP_PATH, O_RDONLY);
+	if (fd < 0) {
+		return -1;
+	}
+
+	if (smack_set_onlycap_from_file(fd)) {
+		close(fd);
+		return -1;
+	}
+	close(fd);
+
 	return 0;
 }
 
@@ -1237,5 +1249,114 @@ int smack_set_relabel_self(const char **labels, int cnt)
 out:
 	free(buf);
 	close(fd);
+	return ret;
+}
+
+int smack_set_onlycap(const char **labels, int cnt)
+{
+	int i;
+	int ret;
+	int fd = -1;
+	char *buf = NULL;
+	int size = 0;
+	int len;
+
+	if (init_smackfs_mnt())
+		return -1;
+
+	fd = openat(smackfs_mnt_dirfd, "onlycap", O_WRONLY);
+	if (fd < 0)
+		return -1;
+
+	if (labels && cnt) {
+		buf = malloc((SMACK_LABEL_LEN + 1) * cnt);
+		if (buf == NULL) {
+			close(fd);
+			return -1;
+		}
+
+		for (i = 0; i < cnt; ++i) {
+			len = get_label(buf + size, labels[i], NULL);
+			if (len <= 0) {
+				ret = -1;
+				goto out;
+			}
+			size += len;
+			buf[size++] = ' ';
+		}
+		if (write(fd, buf, size) < 0)
+			ret = -1;
+		else
+			ret = 0;
+	} else { /* emtpy list: reset onlycap */
+		if (write(fd, " ", 1) < 0)
+			ret = -1;
+		else
+			ret = 0;
+	}
+
+out:
+	free(buf);
+	close(fd);
+	return ret;
+}
+
+int smack_set_onlycap_from_file(int fd)
+{
+	int ret = 0;
+	int newfd = dup(fd);
+	if (newfd == -1)
+		return -1;
+
+	FILE *file = fdopen(newfd, "r");
+	if (file == NULL) {
+		close(newfd);
+		return -1;
+	}
+
+	char buf[SMACK_LABEL_LEN + 2];
+	int cnt = 0;
+	int size = 10;
+	char **labels = malloc(sizeof(char *) * size);
+	if (labels == NULL) {
+		fputs("Out of memory.\n", stderr);
+		ret = -1;
+		goto out;
+	}
+
+	while (!feof(file)) {
+		if (fscanf(file, "%s", buf) > 0) {
+			if (cnt == size) {
+				size = size * 2;
+				char **new_labels = realloc(labels, sizeof(char *) * size);
+				if (new_labels == NULL) {
+					fputs("Out of memory.\n", stderr);
+					ret = -1;
+					goto out;
+				}
+				labels = new_labels;
+			}
+			int label_len = strlen(buf);
+			char *label = malloc(label_len + 1);
+			if (label == NULL) {
+				fputs("Out of memory.\n", stderr);
+				ret = -1;
+				goto out;
+			}
+			if (get_label(label, buf, NULL) <= 0) {
+				free(label);
+				ret = -1;
+				goto out;
+			}
+			labels[cnt++] = label;
+		}
+	}
+	ret = smack_set_onlycap((const char **)labels, cnt);
+out:
+	fclose(file);
+	int i;
+	for (i = 0; i < cnt; ++i)
+		free(labels[i]);
+	free(labels);
 	return ret;
 }

--- a/libsmack/libsmack.sym
+++ b/libsmack/libsmack.sym
@@ -38,3 +38,9 @@ LIBSMACK_1.2 {
 global:
 	smack_set_relabel_self;
 } LIBSMACK_1.1;
+
+LIBSMACK_1.3 {
+global:
+	smack_set_onlycap;
+	smack_set_onlycap_from_file;
+} LIBSMACK_1.2;

--- a/libsmack/sys/smack.h
+++ b/libsmack/sys/smack.h
@@ -322,6 +322,7 @@ ssize_t smack_label_length(const char *label);
  * This function loads the Smack policy from default location and loads
  * it to kernel. Smackfs file system must be alreadt mounted.
  * It is designed for init process to load the policy at system startup.
+ * It also sets up CIPSO and onlycap list of labels.
  *
  * @return Returns 0 on success and negative on failure.
  */
@@ -339,6 +340,34 @@ int smack_load_policy(void);
  * @return Returns 0 on success and negative on failure.
  */
 int smack_set_relabel_self(const char **labels, int cnt);
+
+/*!
+ * Set the list of labels that will be allowed to have effective CAP_MAC_ADMIN
+ * and CAP_MAC_OVERRIDE. This set of labels will be applied (written)
+ * to the kernel interface "onlycap". Setting empty list causes CAP_MAC_ADMIN &
+ * CAP_MAC_OVERRIDE to be unconstrained by any specific Smack label. Empty
+ * list of onlycap Smack labels is the default kernel configuration. The caller
+ * must have CAP_MAC_ADMIN capability. Caller may effectively loose
+ * the capability after successful return from the function if its Smack label
+ * is not on the list of labels.
+ *
+ * @param labels list of labels (NULL for empty list)
+ * @param cnt number of labels (0 for empty list)
+ * @return Returns 0 on success and negative value on failure
+ *
+ */
+int smack_set_onlycap(const char **labels, int cnt);
+
+
+/*!
+ * Set the list of labels that will be allowed to have effective CAP_MAC_ADMIN
+ * and CAP_MAC_OVERRIDE. This function reads list of labels from file path
+ * passed as argument and calls smack_set_onlycap afterwards.
+ *
+ * @param fd file descriptor to the file containing list of onlycap Smack labels
+ * @return Returns 0 on success and negative value on failure
+ */
+int smack_set_onlycap_from_file(int fd);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
smack_set_onlycap applies the list of supplied labels to kernel.
Its usage in smack_load_policy() searches for the text file
with list of labels in /etc/smack/onlycap (each label
in separate line). smack_set_onlycap_from_file usage was also added
to smack_load_policy() function.

Signed-off-by: Tomasz Swierczek <t.swierczek@samsung.com>