### PR TITLE
libsmack: add new function for retrieving Smack label of any process

### DIFF
--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -35,6 +35,7 @@
 #include <sys/xattr.h>
 
 #define SELF_LABEL_FILE "/proc/self/attr/current"
+#define PID_LABEL_FILE "/proc/%d/attr/current"
 
 #define SHORT_LABEL_LEN 23
 #define ACC_LEN 6
@@ -576,14 +577,14 @@ const char *smack_smackfs_path(void)
 	return smackfs_mnt;
 }
 
-ssize_t smack_new_label_from_self(char **label)
+static ssize_t smack_new_label_from_proc(const char *proc_path, char **label)
 {
 	char buf[SMACK_LABEL_LEN + 1];
 	char *result;
 	int fd;
 	int ret;
 
-	fd = open(SELF_LABEL_FILE, O_RDONLY);
+	fd = open(proc_path, O_RDONLY);
 	if (fd < 0)
 		return -1;
 
@@ -606,6 +607,19 @@ ssize_t smack_new_label_from_self(char **label)
 
 	*label = result;
 	return ret;
+}
+
+ssize_t smack_new_label_from_self(char **label)
+{
+	return smack_new_label_from_proc(SELF_LABEL_FILE, label);
+}
+
+ssize_t smack_new_label_from_process(pid_t pid, char **label)
+{
+	char path[sizeof(PID_LABEL_FILE) + 20];
+
+	sprintf(path, PID_LABEL_FILE, pid);
+	return smack_new_label_from_proc(path, label);
 }
 
 ssize_t smack_new_label_from_socket(int fd, char **label)

--- a/libsmack/libsmack.sym
+++ b/libsmack/libsmack.sym
@@ -43,4 +43,5 @@ LIBSMACK_1.3 {
 global:
 	smack_set_onlycap;
 	smack_set_onlycap_from_file;
+	smack_new_label_from_process;
 } LIBSMACK_1.2;

--- a/libsmack/sys/smack.h
+++ b/libsmack/sys/smack.h
@@ -202,6 +202,17 @@ const char *smack_smackfs_path(void);
 ssize_t smack_new_label_from_self(char **label);
 
 /*!
+  * Get the label that is associated with the given process.
+  * Caller is responsible of freeing the returned label.
+  *
+  * @param pid process descriptor to get the label for
+  * @param label output variable for the label
+  * @return Returns length of the label on success and negative value
+  * on failure.
+  */
+ssize_t smack_new_label_from_process(pid_t pid, char **label);
+
+/*!
   * Get the label that is associated with a peer on the other end of a
   * UDS socket (SO_PEERSEC). Caller is responsible of freeing the returned
   * label.


### PR DESCRIPTION
Until now libsmack provided only function for returning Smack label of the calling process. But it is often needed to get label of another process. User programs needed to implement this by themselves by accessing appropriate procfs interface.

Add new function smack_new_label_from_process that takes PID of the process and returns its label.