### PR TITLE
Add the command 'test' to smackctl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.60)
 AC_INIT([libsmack],
-	[1.3.1],
+	[1.3.2],
 	[r.krypa@samsung.com],
 	[libsmack],
 	[https://github.com/smack-team/smack])

--- a/doc/smackctl.8
+++ b/doc/smackctl.8
@@ -20,25 +20,61 @@
 .SH NAME
 smackctl \- Load and unload the system Smack rules files
 .SH SYNOPSIS
-.B smackctl ['apply'] ['clear'] ['status']
+.B smackctl ACTION
 
 .SH DESCRIPTION
+
 .B smackctl
 is a program to load and unload the Smack context configurations.  It is generally called by an init process on startup and shutdown of the system when it is needed to change the Smack rules in the kernel.  The Smack system configuration files are stored in configuration directories (see FILES below).
-.SH OPTIONS
+
+.B smackctl
+can also be used to check the status of the Smack system, specifically if smackfs filesystem is mounted.
+
+.SH ACTIONS
+
+.B
 .IP apply
 Apply all the rules found in the configuration directories (/etc/smack/accesses.d and /etc/smack/cipso.d)
+
+.B
 .IP clear
 Remove all system rules from the kernel.
+
+.B
 .IP status
 Show the status of the Smack system, specifically if smackfs filesystem is mounted and where.
+
+.B
+.IP test
+Test the status of the Smack system, specifically if smackfs filesystem is mounted and exit appropriately without prompting norder to indicate to scripts whether Smack is active or not.
+
+.SH OPTIONS
+
+.IP -h --help
+Print a short help and exit immediately.
+
+.IP -v --version
+Print the version and exit immediately.
+
 .SH EXIT STATUS
-On success
+
+Except for action
+.B test
+, on success
 .B smackctl
 returns 0 and 1 on failure.
+
+If action is
+.B test
+the exit value 0 indicates that the Smack system is active, otherwise, if Smack system is not detected active, the exit value is 2 (see NOTE).
+
 .SH FILES
 /smack or /sys/fs/smackfs
 .br
 /etc/smack/acceses.d
 .br
 /etc/smack/cipso.d
+
+.SH NOTE
+
+The value 2 is used in exiting of test to be distinguished from normal error cases. Versions of smackctl anterior to version 1.3.2 would not recognizes the action test and thus will exit with status 1 indicating a wrong action.

--- a/utils/smackctl.c
+++ b/utils/smackctl.c
@@ -39,6 +39,7 @@ static const char usage[] =
 	" clear   remove all system rules from the kernel\n"
 	" status  show the status of the Smack system, specifically if "
 	       "smackfs is mounted\n"
+	" test    test if Smack is active (exit 0) or inactive (exit 1).\n"
 ;
 
 static const char short_options[] = "vh";
@@ -91,8 +92,11 @@ int main(int argc, char **argv)
 		else
 			printf("SmackFS is not mounted.\n");
 		exit(0);
+	} else if (!strcmp(argv[1], "test")) {
+		if (!smack_smackfs_path())
+			exit(2);
 	} else {
-		fprintf(stderr, "Uknown action: %s\n", argv[1]);
+		fprintf(stderr, "Unknown action: %s\n", argv[1]);
 		fprintf(stderr, usage, argv[0]);
 		exit(1);
 	}


### PR DESCRIPTION
The command 'test' is similar to the
command 'status' but instead of displaying
the status, it returns a status: 0 if smackFS
is mounted or 1 otherwise.

The intention is to provide a cleaner interface
for scripting. Instead of writing

 if smackctl status | grep -qv ' not '; then ...

the script progreammer can simply write

 if smackctl test; then ...

Signed-off-by: José Bollo <jose.bollo@iot.bzh>