### PR TITLE
chsmack: Avoid duplicate slashs

### DIFF
--- a/utils/chsmack.c
+++ b/utils/chsmack.c
@@ -252,6 +252,8 @@ static void explore(const char *path, void (*fun)(const char*), int follow)
 
 	if (path) {
 		memcpy(buf, path, dir_name_len);
+		while (dir_name_len && buf[dir_name_len - 1] == '/')
+			dir_name_len--;
 		buf[dir_name_len] = '/';
 	} else {
 		buf[0] = '.';


### PR DESCRIPTION
When the command chsmack is called for recursive
exploration, if the given path(s) end with /, it
produced output with 2 slashes.

Exemple before:

  $ chsmack -r here/
  here//i-am: access="_"
  here//you-are: access="_"

Exemple after:

  $ chsmack -r here/
  here/i-am: access="_"
  here/you-are: access="_"

Note that slash at tail are often produced by
automatic completion and/or scripts.