### PR TITLE
[DRAFT] Add PAM module for smack

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,4 +4,4 @@ AM_MAKEFLAGS = --no-print-directory
 DISTCHECK_CONFIGURE_FLAGS = \
 	--with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir)
 
-SUBDIRS = libsmack utils doc init
+SUBDIRS = libsmack utils doc init pam

--- a/configure.ac
+++ b/configure.ac
@@ -1,9 +1,10 @@
 AC_PREREQ(2.60)
 AC_INIT([libsmack],
-	[1.3.2],
+	[1.3.3],
 	[r.krypa@samsung.com],
 	[libsmack],
 	[https://github.com/smack-team/smack])
+
 AC_CONFIG_SRCDIR([libsmack/libsmack.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([utils/config.h])
@@ -27,6 +28,16 @@ AM_CONDITIONAL([ENABLE_DOXYGEN],[test ! -z "$DOXYGEN"], [Build API documentation
 AM_COND_IF([ENABLE_DOXYGEN], [AC_CONFIG_FILES([doc/Doxyfile])])
 AC_SUBST([DOXYGEN], [$DOXYGEN])
 
+#pam
+AC_ARG_ENABLE(securedir,
+	AS_HELP_STRING([--enable-securedir=DIR],[path to location of PAMs @<:@default=$libdir/security@:>@]),
+	SECUREDIR=$enableval, SECUREDIR=$libdir/security)
+AC_SUBST(SECUREDIR)
+
+AC_CHECK_HEADER([security/pam_modules.h],[PAM_HEADER=yes])
+AC_CHECK_LIB([pam],pam_get_user,[PAM_LIB=yes])
+AM_CONDITIONAL([PAM], [test x$PAM_HEADER = xyes -a x$PAM_LIB = xyes])
+
 # systemd
 systemd_new=no
 PKG_CHECK_MODULES([SYSTEMD],
@@ -42,6 +53,13 @@ AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
 AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$with_systemdsystemunitdir"])
 AM_CONDITIONAL(HAVE_SYSTEMD_NEW, [test "$systemd_new" = "yes"])
 
-AC_CONFIG_FILES([Makefile libsmack/Makefile libsmack/libsmack.pc utils/Makefile doc/Makefile init/Makefile])
+AC_CONFIG_FILES([
+	Makefile
+	libsmack/Makefile
+	libsmack/libsmack.pc
+	utils/Makefile
+	doc/Makefile
+	pam/Makefile
+	init/Makefile])
 
 AC_OUTPUT

--- a/pam/Makefile.am
+++ b/pam/Makefile.am
@@ -1,0 +1,13 @@
+
+pam_moduledir = $(SECUREDIR)
+pam_module_LTLIBRARIES = 
+man_MANS =
+if PAM
+  pam_module_LTLIBRARIES += pam_smack.la
+  man_MANS += pam_smack.8
+endif
+AM_LDFLAGS = -no-undefined -avoid-version -module
+AM_CPPFLAGS = -I$(top_srcdir)/libsmack
+pam_smack_la_SOURCES = pam_smack.c
+pam_smack_la_LIBADD = -lpam $(top_srcdir)/libsmack/libsmack.la $(top_srcdir)/libsmack/libsmackcommon.la
+EXTRA_DIST = $(man_MANS)

--- a/pam/pam_smack.8
+++ b/pam/pam_smack.8
@@ -1,0 +1,61 @@
+.\" -*- coding: us-ascii -*-
+.if \n(.g .ds T< \\FC
+.if \n(.g .ds T> \\F[\n[.fam]]
+.de URL
+\\$2 \(la\\$1\(ra\\$3
+..
+.if \n(.g .mso www.tmac
+.TH pam_smack 8 "6 May 2022" "Linux-PAM Manual" ""
+.SH NAME
+pam_smack \- PAM module to set the default security context
+.SH SYNOPSIS
+'nh
+.fi
+.ad l
+\fBpam_smack.so\fR \kx
+.if (\nx>(\n(.l/2)) .nr x (\n(.l/5)
+'in \n(.iu+\nxu
+[
+user=label
+]\&... [
+=default-label
+]
+'in \n(.iu-\nxu
+.ad b
+'hy
+.SH DESCRIPTION
+pam_smack is a PAM module that sets up the default Smack security
+context for the next executed process.
+.PP
+When a new session is started, the open_session part of the module
+computes and sets up the execution security context used for the
+current process, based on the user account.
+.SH OPTIONS
+.TP 
+\*(T<\fBuser=label\fR\*(T> 
+Set the label if it is the user.
+.TP 
+\*(T<\fB=default\-label\fR\*(T> 
+Label to set if no user matches.
+.SH "MODULE TYPES PROVIDED"
+Only the \*(T<\fBsession\fR\*(T> module type is provided.
+.SH "RETURN VALUES"
+.TP 
+PAM_SUCCESS
+The security context was set successfully.
+.TP 
+PAM_SESSION_ERR
+Unable to get or set a valid context.
+.SH EXAMPLES
+.nf
+\*(T<
+auth     required  pam_unix.so
+session  required  pam_permit.so
+session  optional  pam_smack.so root=System =User
+    \*(T>
+.fi
+.SH "SEE ALSO"
+\fBpam.d\fR(5),
+\fBpam\fR(8)
+.SH AUTHOR
+pam_smack was written by Jos\('e Bollo <jose.bollo@iot.bzh>.

--- a/pam/pam_smack.8.xml
+++ b/pam/pam_smack.8.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding='UTF-8'?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
+	"http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd">
+
+<refentry id="pam_smack">
+
+  <refmeta>
+    <refentrytitle>pam_smack</refentrytitle>
+    <manvolnum>8</manvolnum>
+    <refmiscinfo class="sectdesc">Linux-PAM Manual</refmiscinfo>
+  </refmeta>
+
+  <refnamediv id="pam_smack-name">
+    <refname>pam_smack</refname>
+    <refpurpose>PAM module to set the default security context</refpurpose>
+  </refnamediv>
+
+  <refsynopsisdiv>
+    <cmdsynopsis id="pam_smack-cmdsynopsis">
+      <command>pam_smack.so</command>
+      <arg choice="opt" rep="repeat">
+	user=label
+      </arg>
+      <arg choice="opt">
+	=default-label
+      </arg>
+    </cmdsynopsis>
+  </refsynopsisdiv>
+
+  <refsect1 id="pam_smack-description">
+    <title>DESCRIPTION</title>
+    <para>
+      pam_smack is a PAM module that sets up the default Smack security
+      context for the next executed process.
+    </para>
+    <para>
+      When a new session is started, the open_session part of the module
+      computes and sets up the execution security context used for the
+      current process, based on the user account.
+    </para>
+  </refsect1>
+
+  <refsect1 id="pam_smack-options">
+    <title>OPTIONS</title>
+    <variablelist>
+      <varlistentry>
+        <term>
+          <option>user=label</option>
+        </term>
+        <listitem>
+          <para>
+            Set the label if it is the user.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>
+          <option>=default-label</option>
+        </term>
+        <listitem>
+          <para>
+            Label to set if no user matches.
+          </para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </refsect1>
+
+  <refsect1 id="pam_smack-types">
+    <title>MODULE TYPES PROVIDED</title>
+    <para>
+      Only the <option>session</option> module type is provided.
+    </para>
+  </refsect1>
+
+  <refsect1 id='pam_smack-return_values'>
+    <title>RETURN VALUES</title>
+    <variablelist>
+      <varlistentry>
+        <term>PAM_SUCCESS</term>
+        <listitem>
+          <para>
+            The security context was set successfully.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>PAM_SESSION_ERR</term>
+        <listitem>
+          <para>
+            Unable to get or set a valid context.
+          </para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </refsect1>
+
+  <refsect1 id='pam_smack-examples'>
+    <title>EXAMPLES</title>
+    <programlisting>
+auth     required  pam_unix.so
+session  required  pam_permit.so
+session  optional  pam_smack.so root=System =User
+    </programlisting>
+  </refsect1>
+
+  <refsect1 id='pam_smack-see_also'>
+    <title>SEE ALSO</title>
+    <para>
+      <citerefentry>
+	<refentrytitle>pam.d</refentrytitle><manvolnum>5</manvolnum>
+      </citerefentry>,
+      <citerefentry>
+	<refentrytitle>pam</refentrytitle><manvolnum>8</manvolnum>
+      </citerefentry>
+    </para>
+  </refsect1>
+
+  <refsect1 id='pam_smack-author'>
+    <title>AUTHOR</title>
+      <para>
+        pam_smack was written by Jos&eacute; Bollo &lt;jose.bollo@iot.bzh&gt;.
+      </para>
+  </refsect1>
+
+</refentry>

--- a/pam/pam_smack.c
+++ b/pam/pam_smack.c
@@ -1,0 +1,86 @@
+#define _GNU_SOURCE
+#include <string.h>
+#include <syslog.h>
+#include <sys/smack.h>
+
+#define PAM_SM_SESSION
+#include <security/pam_modules.h>
+#include <security/pam_modutil.h>
+#include <security/pam_ext.h>
+
+#define DEFAULT_LABEL "User"
+
+PAM_EXTERN int
+pam_sm_close_session (pam_handle_t *pamh, int flags,
+                      int argc, const char **argv)
+{
+  return PAM_IGNORE;
+}
+
+/*
+When opening session, the arguments are searched for a value
+of kind "user=label". If not found, but the value "=label" exists
+in parameters, it will be used.
+Otherwise, the value DEFAULT_LABEL is used.
+When the value of the label is the empty string, no change is made.
+*/
+
+PAM_EXTERN int 
+pam_sm_open_session (pam_handle_t *pamh,
+         int flags,
+         int argc,
+         const char **argv)
+{
+  const char *label = NULL;
+  int rc, idx;
+  unsigned lenu;
+  const char *user;
+  if (smack_smackfs_path ()) {
+    /* compute the label for the user */
+    rc = pam_get_user(pamh, &user, NULL);
+    if (rc == PAM_SUCCESS && user != NULL && *user != '\0') {
+      lenu = (unsigned)strlen(user);
+      for (idx = 0 ; idx < argc && label == NULL ; idx++) {
+        if (0 == strncmp(argv[idx], user, lenu)
+         && argv[idx][lenu] == '='
+         &&  argv[idx][lenu + 1] != '\0') {
+          /* set label if arg is "user=label" */
+          label = &argv[idx][lenu + 1];
+	 }
+      }
+    }
+    /* compute the default label if none is set for user */
+    if (label == NULL) {
+      for (idx = 0 ; idx < argc && label == NULL ; idx++)
+	if (argv[idx][0] == '=')
+          label = &argv[idx][1];
+      if (label == NULL)
+        label = DEFAULT_LABEL;
+    }
+    if (label != NULL && *label != '\0') {
+      rc = smack_set_label_for_self (label);
+      if (rc) {
+        pam_syslog (pamh, LOG_WARNING, "couldn't set Smack's label");
+        return PAM_SESSION_ERR;
+      }
+    }
+  }
+  return PAM_SUCCESS;
+}
+
+#ifdef PAM_STATIC
+
+/* static module data */
+
+struct pam_module _pam_smack_modstruct = {
+  "pam_smack",
+  NULL,
+  NULL,
+  NULL,
+  pam_sm_open_session,
+  pam_sm_close_session,
+  NULL,
+};
+
+#endif
+


### PR DESCRIPTION
This is a draft for review

There are currently some existing PAM module for Smack:
 - in tizen
 - in smack-util (from github)

But there is no official places for some PAM module for Smack. For this reason I think that here is the good place.

The module I propose can behave like the module of tizen if invoked as below:
```
session optional pam_smack.so =User
```
