### PR TITLE
Tiny modernization of chsmack and libsmack

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.60)
 AC_INIT([libsmack],
-	[1.3.3],
+	[1.4.0],
 	[r.krypa@samsung.com],
 	[libsmack],
 	[https://github.com/smack-team/smack])

--- a/doc/chsmack.8
+++ b/doc/chsmack.8
@@ -28,8 +28,6 @@ chsmack \- Change or list the Smack properties of filesystem objects
 
 .B chsmack [-L] [-r] props... [--] files...
 
-chsmack -d [-L] [-r] [props]... [--] files...
-
 .SH DESCRIPTION
 
 \fBchsmack\fR can be used to query or change the Smack context of a file.
@@ -37,10 +35,6 @@ chsmack -d [-L] [-r] [props]... [--] files...
 First form is used to query the Smack properties of the files.
 
 Second form is used to set and reset some Smack properties to the files.
-
-Third form is used to remove all or some of the Smack properties of the
-listed files.
-\fBThis third form is now obsolete, use second form instead.\fR
 
 Depending on the state and type of the file the different labels,
 which are stored as extended attributes, have a different effect.
@@ -162,20 +156,6 @@ be removed.
 
 Use this option to list or modify files in subdirectories.
 It follows symbolic links only if in the command line.
-
-.SH OBSOLETE OPTIONS
-
-.TP
-.B -d, --remove
-
-\fBThis option is obsolete, use -D, -A, -M -E, -T instead.\fR
-
-Use this option to remove the smack properties of the files.
-You specify the properties to remove using options \fB-a\fR, \fB-e\fR,
-\fB-m\fR or \fB-t\fR (or their long version) without putting their label
-value.
-If no property is specified, it means that all the properties will
-be removed.
 
 .SH RETURN VALUE
 

--- a/doc/chsmack.8
+++ b/doc/chsmack.8
@@ -22,26 +22,26 @@
 
 chsmack \- Change or list the Smack properties of filesystem objects
 
-.SH SYNOPSIS 
+.SH SYNOPSIS
 
-.B chsmack [-L] [-r] [--] files...
+.B chsmack [-L] [-r] [-n] [filters...] [--] files...
 
-.B chsmack [-L] [-r] props... [--] files...
+.B chsmack [-L] [-r] [filters...] settings... [--] files...
 
 .SH DESCRIPTION
 
 \fBchsmack\fR can be used to query or change the Smack context of a file.
 
-First form is used to query the Smack properties of the files.
+First form is used to query Smack properties of files.
 
-Second form is used to set and reset some Smack properties to the files.
+Second form is used to set and reset some Smack properties to files.
 
 Depending on the state and type of the file the different labels,
 which are stored as extended attributes, have a different effect.
-The \fIaccess\fR property is always significant. 
-It is used to control how process access the file.  
+The \fIaccess\fR property is always significant.
+It is used to control how process access the file.
 The \fImmap\fR property is significant on filesystem object that can be mapped.
-It is used to control how process mmap the file.  
+It is used to control how process mmap the file.
 The \fIexec\fR property apply on executable files (binary or scripts).
 It take effect when the process is launched and the property
 will be assigned as the context of the running process.
@@ -52,7 +52,7 @@ the label of the directory on which the transmute bit is set.
 This process needs to be launched with \fBCAP_MAC_ADMIN\fR capabilities
 in order to change any of the contexts.
 
-.SH OPTIONS
+.SH GENERAL OPTIONS
 
 .TP
 .B -L, --dereference
@@ -61,17 +61,31 @@ Use this option to process the target of the symbolic links instead of the
 symbolic links themselves.
 
 .TP
+.B -r, --recursive
+
+Use this option to list or modify files in subdirectories.
+It follows symbolic links only if in the command line.
+
+.TP
+.B -n, --name-only
+
+When querying files, only print the name. It can be usefull when filtering
+to get a list of files matching a criteria.
+
+.SH SETTING OPTIONS
+
+.TP
 .B -a, --access \fRlabel
 
 When setting, the label must be set and its value must be a valid
 Smack label.
 
 This context is used to confine the access modes, which are defined by the
-set \fBrwaxtl\fR, which refer to read, write, append, execute, transmute 
+set \fBrwaxtl\fR, which refer to read, write, append, execute, transmute
 and lock.
 The exec here is not to be confused with the \fB\-e\fR option listed below.
 This access mode "exec" specifies restrictions on who is allowed
-to launch this process. 
+to launch this process.
 A common rule for this might look like \fB(launcher application rx)\fR
 where the \fB\-\-access\fR label is set to \fBapplication\fR.
 This would ensure that the process with context \fBlauncher\fR would be able
@@ -151,11 +165,89 @@ For example chsmack -a Foo -D would drop all attributes except security.SMACK64.
 If no property is specified, it means that all the properties will
 be removed.
 
-.TP
-.B -r, --recursive
+.SH FILTERING OPTIONS
 
-Use this option to list or modify files in subdirectories.
-It follows symbolic links only if in the command line.
+Filtering options allow to select the files that will be either printed
+or modified. Filtering is possible on any Smack attribute. For each
+attribute, it is possible to check:
+
+- if there is no value (\fB--if-no-...\fR family)
+
+- if the value is exactly the given text
+
+- if there is no value or the value doesn't match the given text
+
+The former case is when the given text starts with a slash (\fB/\fR),
+see examples for details.
+
+When more than one filtering option is given, a logical and is applied,
+meaning that the file is selected only if all filtering options match.
+
+.TP
+.B --if-access VALUE
+
+If \fBVALUE\fR doesn't start with a slash (\fB/\fR), the file matches
+if its extended attribute \fBsecurity.SMACK64\fR equals \fBVALUE\fR.
+
+If \fBVALUE\fR starts with a slash (\fB/\fR), being like \fB/TEXT\fR,
+the file matches either if it doesn't have the extended attribute
+\fBsecurity.SMACK64\fR or if its value isn't equal to \fBTEXT\fR.
+
+Note that on Smack system, the extended attribute \fBsecurity.SMACK64\fR
+is always defined.
+
+.TP
+.B --if-no-access
+
+The file matches if doesn't have the extended attribute
+\fBsecurity.SMACK64\fR.
+
+Note that on Smack system, the extended attribute \fBsecurity.SMACK64\fR
+is always defined.
+
+.TP
+.B --if-exec VALUE
+
+If \fBVALUE\fR doesn't start with a slash (\fB/\fR), the file matches
+if its extended attribute \fBsecurity.SMACK64EXEC\fR equals \fBVALUE\fR.
+
+If \fBVALUE\fR starts with a slash (\fB/\fR), being like \fB/TEXT\fR,
+the file matches either if it doesn't have the extended attribute
+\fBsecurity.SMACK64EXEC\fR or if its value isn't equal to \fBTEXT\fR.
+
+.TP
+.B --if-no-exec
+
+The file matches if doesn't have the extended attribute
+\fBsecurity.SMACK64EXEC\fR.
+
+.TP
+.B --if-mmap VALUE
+
+If \fBVALUE\fR doesn't start with a slash (\fB/\fR), the file matches
+if its extended attribute \fBsecurity.SMACK64MMAP\fR equals \fBVALUE\fR.
+
+If \fBVALUE\fR starts with a slash (\fB/\fR), being like \fB/TEXT\fR,
+the file matches either if it doesn't have the extended attribute
+\fBsecurity.SMACK64MMAP\fR or if its value isn't equal to \fBTEXT\fR.
+
+.TP
+.B --if-no-mmap
+
+The file matches if doesn't have the extended attribute
+\fBsecurity.SMACK64MMAP\fR.
+
+.TP
+.B --if-transmute
+
+The file matches if has the extended attribute
+\fBsecurity.SMACK64TRANSMUTE\fR equals to \fBTRUE\fR.
+
+.TP
+.B --if-no-transmute
+
+The file matches if doesn't have the extended attribute
+\fBsecurity.SMACK64TRANSMUTE\fR.
 
 .SH RETURN VALUE
 
@@ -206,6 +298,21 @@ chsmack -E -a Nobody file3
 
 This command set the Smack \fIaccess\fR property to \fINobody\fR and
 drops the \fIexec\fR property for the file \fIfile3\fR.
+
+.EX
+chsmack --if-exec spurious -E -a Nobody -r /
+.EE
+
+This command set the Smack \fIaccess\fR property to \fINobody\fR and
+drops the \fIexec\fR property of any file that have the \fIexec\fR
+label \fIspurious\fR.
+
+.EX
+chsmack --if-access /user0 -n -r /home/user0
+.EE
+
+This command lists all files of \fI/home/user0\fR that doesn't have
+\fIaccess\fR property equal to \fIuser0\fR.
 
 .SH "SEE ALSO"
 

--- a/libsmack/libsmack.c
+++ b/libsmack/libsmack.c
@@ -245,7 +245,7 @@ static int accesses_add(struct smack_accesses *handle, const char *subject,
 	struct smack_label *subject_label;
 	struct smack_label *object_label;
 
-	rule = calloc(sizeof(struct smack_rule), 1);
+	rule = calloc(1, sizeof(struct smack_rule));
 	if (rule == NULL)
 		return -1;
 
@@ -419,7 +419,7 @@ int smack_cipso_new(struct smack_cipso **cipso)
 {
 	struct smack_cipso *result;
 
-	result = calloc(sizeof(struct smack_cipso), 1);
+	result = calloc(1, sizeof(struct smack_cipso));
 	if (result == NULL)
 		return -1;
 
@@ -533,7 +533,7 @@ int smack_cipso_add_from_file(struct smack_cipso *cipso, int fd)
 	}
 
 	while (getline(&buf, &buf_size, file) >= 0) {
-		mapping = calloc(sizeof(struct cipso_mapping), 1);
+		mapping = calloc(1, sizeof(struct cipso_mapping));
 		if (mapping == NULL)
 			goto err_out;
 
@@ -623,7 +623,7 @@ static ssize_t smack_new_label_from_proc(const char *proc_path, char **label)
 
 	buf[ret] = '\0';
 
-	result = calloc(ret + 1, 1);
+	result = calloc(1, ret + 1);
 	if (result == NULL)
 		return -1;
 
@@ -680,7 +680,7 @@ ssize_t smack_new_label_from_socket(int fd, char **label)
 
 	buf[length] = '\0';
 
-	result = calloc(length + 1, 1);
+	result = calloc(1, length + 1);
 	if (result == NULL)
 		return -1;
 
@@ -708,7 +708,7 @@ ssize_t smack_new_label_from_path(const char *path, const char *xattr,
 		return -1;
 	buf[ret] = '\0';
 
-	result = calloc(ret + 1, 1);
+	result = calloc(1, ret + 1);
 	if (result == NULL)
 		return -1;
 
@@ -734,7 +734,7 @@ ssize_t smack_new_label_from_file(int fd, const char *xattr,
 		return -1;
 	buf[ret] = '\0';
 
-	result = calloc(ret + 1, 1);
+	result = calloc(1, ret + 1);
 	if (result == NULL)
 		return -1;
 

--- a/utils/chsmack.c
+++ b/utils/chsmack.c
@@ -416,6 +416,10 @@ int main(int argc, char *argv[])
 	/* process */
 	fun = modify ? modify_file : print_file;
 	if (optind == argc) {
+		if (recursive_flag == unset) {
+			fprintf(stderr, "error: no files.\n");
+			exit(1);
+		}
 		explore(NULL, fun, 0);
 	} else {
 		for (i = optind; i < argc; i++) {

--- a/utils/chsmack.c
+++ b/utils/chsmack.c
@@ -115,6 +115,17 @@ static struct option *option_by_char(int car)
 	return result;
 }
 
+/* get a string describing the option for the given char */
+static const char *describe_option(int car)
+{
+	static char buffer[50];
+	struct option *opt = option_by_char(car);
+	snprintf(buffer, sizeof buffer, "--%s (or -%c)",
+			opt->name, opt->val);
+	return buffer;
+}
+
+
 /* modify attributes of a file */
 static void modify_prop(const char *path, struct labelset *ls, const char *attr)
 {
@@ -312,15 +323,15 @@ static void set_state(enum state *to, enum state value, int car, int fatal)
 	if (*to == unset)
 		*to = value;
 	else if (*to == value) {
-		fprintf(stderr, "%s, option --%s or -%c already set.\n",
+		fprintf(stderr, "%s, option %s already set.\n",
 			fatal ? "error" : "warning",
-			option_by_char(car)->name, option_by_char(car)->val);
+			describe_option(car));
 		if (fatal)
 			exit(1);
 	} else {
-		fprintf(stderr, "error, option --%s or -%c opposite to an "
+		fprintf(stderr, "error, option %s opposite to an "
 			"option already set.\n",
-			option_by_char(car)->name, option_by_char(car)->val);
+			describe_option(car));
 		exit(1);
 	}
 }
@@ -329,12 +340,12 @@ static void set_state(enum state *to, enum state value, int car, int fatal)
 static void set_label(struct labelset *label, const char *value, int car)
 {
 	if (strnlen(value, SMACK_LABEL_LEN + 1) == SMACK_LABEL_LEN + 1) {
-		fprintf(stderr, "%s: \"%s\" exceeds %d characters.\n",
-			option_by_char(car)->name, value, SMACK_LABEL_LEN);
+		fprintf(stderr, "error option %s: \"%s\" exceeds %d characters.\n",
+			describe_option(car), value, SMACK_LABEL_LEN);
 		exit(1);
 	} else if (smack_label_length(value) < 0) {
-		fprintf(stderr, "%s: invalid Smack label '%s'.\n",
-			option_by_char(car)->name, value);
+		fprintf(stderr, "error option %s: invalid Smack label '%s'.\n",
+			describe_option(car), value);
 		exit(1);
 	}
 

--- a/utils/chsmack.c
+++ b/utils/chsmack.c
@@ -36,6 +36,20 @@
 
 #include "config.h"
 
+#define OC_VERSION        'v'
+#define OC_HELP           'h'
+#define OC_SET_ACCESS     'a'
+#define OC_SET_EXEC       'e'
+#define OC_SET_MMAP       'm'
+#define OC_SET_TRANSMUTE  't'
+#define OC_DROP_ACCESS    'A'
+#define OC_DROP_EXEC      'E'
+#define OC_DROP_MMAP      'M'
+#define OC_DROP_TRANSMUTE 'T'
+#define OC_DROP_OTHERS    'D'
+#define OC_DEREFERENCE    'L'
+#define OC_RECURSIVE      'r'
+
 static const char usage[] =
 	"Usage: %s [options] <path>\n"
 	"Options:\n"  
@@ -56,19 +70,19 @@ static const char usage[] =
 
 static const char shortoptions[] = "vha:e:m:tLDAEMTr";
 static struct option options[] = {
-	{"version", no_argument, 0, 'v'},
-	{"help", no_argument, 0, 'h'},
-	{"access", required_argument, 0, 'a'},
-	{"exec", required_argument, 0, 'e'},
-	{"mmap", required_argument, 0, 'm'},
-	{"transmute", no_argument, 0, 't'},
-	{"dereference", no_argument, 0, 'L'},
-	{"drop", no_argument, 0, 'D'},
-	{"drop-access", no_argument, 0, 'A'},
-	{"drop-exec", no_argument, 0, 'E'},
-	{"drop-mmap", no_argument, 0, 'M'},
-	{"drop-transmute", no_argument, 0, 'T'},
-	{"recursive", no_argument, 0, 'r'},
+	{"version", no_argument, 0, OC_VERSION},
+	{"help", no_argument, 0, OC_HELP},
+	{"access", required_argument, 0, OC_SET_ACCESS},
+	{"exec", required_argument, 0, OC_SET_EXEC},
+	{"mmap", required_argument, 0, OC_SET_MMAP},
+	{"transmute", no_argument, 0, OC_SET_TRANSMUTE},
+	{"dereference", no_argument, 0, OC_DEREFERENCE},
+	{"drop", no_argument, 0, OC_DROP_OTHERS},
+	{"drop-access", no_argument, 0, OC_DROP_ACCESS},
+	{"drop-exec", no_argument, 0, OC_DROP_EXEC},
+	{"drop-mmap", no_argument, 0, OC_DROP_MMAP},
+	{"drop-transmute", no_argument, 0, OC_DROP_TRANSMUTE},
+	{"recursive", no_argument, 0, OC_RECURSIVE},
 	{NULL, 0, 0, 0}
 };
 
@@ -345,52 +359,52 @@ int main(int argc, char *argv[])
 	while ((c = getopt_long(argc, argv, shortoptions, options, NULL)) != -1) {
 
 		switch (c) {
-		case 'a':
+		case OC_SET_ACCESS:
 			set_label(&access_set, optarg, c);
 			modify = 1;
 			break;
-		case 'e':
+		case OC_SET_EXEC:
 			set_label(&exec_set, optarg, c);
 			modify = 1;
 			break;
-		case 'm':
+		case OC_SET_MMAP:
 			set_label(&mmap_set, optarg, c);
 			modify = 1;
 			break;
-		case 'A':
+		case OC_DROP_ACCESS:
 			set_state(&access_set.isset, negative, c, 0);
 			modify = 1;
 			break;
-		case 'E':
+		case OC_DROP_EXEC:
 			set_state(&exec_set.isset, negative, c, 0);
 			modify = 1;
 			break;
-		case 'M':
+		case OC_DROP_MMAP:
 			set_state(&mmap_set.isset, negative, c, 0);
 			modify = 1;
 			break;
-		case 'T':
+		case OC_DROP_TRANSMUTE:
 			set_state(&transmute_flag, negative, c, 0);
 			modify = 1;
 			break;
-		case 't':
+		case OC_SET_TRANSMUTE:
 			set_state(&transmute_flag, positive, c, 0);
 			modify = 1;
 			break;
-		case 'D':
+		case OC_DROP_OTHERS:
 			set_state(&delete_flag, negative, c, 0);
 			break;
-		case 'L':
+		case OC_DEREFERENCE:
 			set_state(&follow_flag, positive, c, 0);
 			break;
-		case 'r':
+		case OC_RECURSIVE:
 			set_state(&recursive_flag, positive, c, 0);
 			break;
-		case 'v':
+		case OC_VERSION:
 			printf("%s (libsmack) version " PACKAGE_VERSION "\n",
 			       basename(argv[0]));
 			exit(0);
-		case 'h':
+		case OC_HELP:
 			printf(usage, basename(argv[0]));
 			exit(0);
 		default:


### PR DESCRIPTION
This set of changes can be splitted in 3 parts:
- tiny modernisation: library now try to use /proc/*/attr/smack/current first and fallbacks to old good /proc/*/attr/current
- fix of warning in usage of calloc function
- modernisation of chsmack

chsmack is changed in the following ways:
- internally it uses symbols instead of character constants
- error messages reporting faulty options are more regular
- an error is reported when no file is given and option -r isn't set (previously it applied on all files of current directory)
- new filtering options are giving much more power to smack administrators